### PR TITLE
Update install script to fix database type error

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -59,7 +59,7 @@ class Install extends StreamlinedInstallMigration
                 )
                 ->addField('handle', $this->string(255)->notNull()->unique())
                 ->addField('label', $this->string(255))
-                ->addField('required', $this->boolean()->defaultValue(0))
+                ->addField('required', $this->boolean()->defaultValue(false))
                 ->addField('instructions', $this->text())
                 ->addField('metaProperties', $this->text()),
 


### PR DESCRIPTION
This PR
  * Updates the install script to set the default value of boolean `required` field to `false`, instead of integer `0`. The other booleans in this script use `true`/`false` as their default values.

This results in a "Couldn’t install plugin." error when trying to install it in CraftCMS after adding it to the dependencies it with composer.

Source: Install on Postgres 9.5 in Scotchbox (https://box.scotch.io/) is throwing a typeerror. See below log snippet
```
2018-02-06 15:59:27 [192.168.33.1][1][-][error][craft\db\MigrationManager::migrateUp] Failed to apply Install (time: 0.013s). Output:
    > create table {{%freeform_forms}} ... done (time: 0.008s)
    > create table {{%freeform_fields}} ...Exception: SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "required" is of type boolean but default expression is of type integer
HINT:  You will need to rewrite or cast the expression.
The SQL being executed was: CREATE TABLE "freeform_fields" (
        "id" serial NOT NULL PRIMARY KEY,
        "type" varchar(255) NOT NULL CHECK ("type" in ('text','textarea','email','hidden','select','checkbox','checkbox_group','radio_group','file','dynamic_recipients','datetime','number','phone','website','rating','regex','confirmation')),
        "handle" varchar(255) NOT NULL UNIQUE,
        "label" varchar(255),
        "required" boolean DEFAULT 0,
        "instructions" text,
        "metaProperties" text,
        "dateCreated" timestamp(0) NOT NULL,
        "dateUpdated" timestamp(0) NOT NULL,
        "uid" char(36) NOT NULL DEFAULT '0'
) (/var/www/vendor/yiisoft/yii2/db/Schema.php:595)
#0 /var/www/vendor/yiisoft/yii2/db/Command.php(1004): yii\db\Schema->convertException(Object(PDOException), 'CREATE TABLE "f...')
#1 /var/www/vendor/yiisoft/yii2/db/Migration.php(299): yii\db\Command->execute()
#2 /var/www/vendor/solspace/craft3-commons/src/Migrations/StreamlinedInstallMigration.php(21): yii\db\Migration->createTable('{{%freeform_fie...', Array, NULL)
#3 /var/www/vendor/craftcms/cms/src/db/Migration.php(44): Solspace\Commons\Migrations\StreamlinedInstallMigration->safeUp()
#4 /var/www/vendor/craftcms/cms/src/db/MigrationManager.php(250): craft\db\Migration->up(true)
#
```