### PR TITLE
Return result of field and form deletion to original request

### DIFF
--- a/src/Controllers/FieldsController.php
+++ b/src/Controllers/FieldsController.php
@@ -219,9 +219,13 @@ class FieldsController extends Controller
 
         $fieldId = \Craft::$app->request->post('id');
 
-        $this->getFieldsService()->deleteById((int) $fieldId);
+        $success = $this->getFieldsService()->deleteById((int) $fieldId);
 
-        return $this->asJson(['success' => true]);
+        if ($success) {
+            return $this->asJson(['success' => true]);
+        } else {
+            return $this->asJson(['error' => 'Couldn’t delete field']);
+        }        
     }
 
     /**

--- a/src/Controllers/FormsController.php
+++ b/src/Controllers/FormsController.php
@@ -228,9 +228,13 @@ class FormsController extends BaseController
         PermissionHelper::requirePermission(Freeform::PERMISSION_FORMS_MANAGE);
 
         $formId = \Craft::$app->request->post('id');
-        $this->getFormService()->deleteById($formId);
+        $success = $this->getFormService()->deleteById($formId);
 
-        return $this->asJson(['success' => true]);
+        if ($success) {
+            return $this->asJson(['success' => true]);
+        } else {
+            return $this->asJson(['error' => 'Couldn’t delete form']);
+        }        
     }
 
     /**


### PR DESCRIPTION
Currently the deleteField and deleteForm controllers always return a success JSON object regardless of whether or not the deletion took place, e.g. it may have been cancelled by the either of the EVENT_BEFORE_DELETE events. At the moment even though the delete request may be cancelled by these events, the UI carries on as if they have been successful, so it is very confusing for the user.