### PR TITLE
Allow reCAPTCHA keys to be set via environment variables

### DIFF
--- a/src/Fields/RecaptchaField.php
+++ b/src/Fields/RecaptchaField.php
@@ -39,7 +39,7 @@ class RecaptchaField extends AbstractField implements NoStorageInterface, Single
         /** @var Settings $settings */
         $settings = Freeform::getInstance()->getSettings();
 
-        $key   = $settings->recaptchaKey;
+        $key   = \Craft::parseEnv($settings->recaptchaKey);
         $type  = $settings->getRecaptchaType();
 
         switch ($type) {

--- a/src/Services/Pro/RecaptchaService.php
+++ b/src/Services/Pro/RecaptchaService.php
@@ -87,7 +87,7 @@ class RecaptchaService extends Component
                     $scriptJs,
                     [
                         'formAnchor' => $event->getForm()->getAnchor(),
-                        'siteKey'    => $model->recaptchaKey,
+                        'siteKey'    => \Craft::parseEnv($model->recaptchaKey),
                         'action' => $event->getForm()->getCustomAttributes()->getRecaptchaAction() ?? 'homepage',
                     ]
                 );
@@ -103,7 +103,7 @@ class RecaptchaService extends Component
                     $scriptJs,
                     [
                         'formAnchor' => $event->getForm()->getAnchor(),
-                        'siteKey'    => $model->recaptchaKey,
+                        'siteKey'    => \Craft::parseEnv($model->recaptchaKey),
                     ]
                 );
 
@@ -115,7 +115,7 @@ class RecaptchaService extends Component
                             data-callback="updateRecaptchaToken" 
                             data-size="invisible"
                             ></div>',
-                        $model->recaptchaKey
+                        \Craft::parseEnv($model->recaptchaKey)
                     )
                 );
                 break;
@@ -167,7 +167,7 @@ class RecaptchaService extends Component
             return false;
         }
 
-        $secret = $this->getSettings()->recaptchaSecret;
+        $secret = \Craft::parseEnv($this->getSettings()->recaptchaSecret);
 
         $client   = new Client();
         $response = $client->post('https://www.google.com/recaptcha/api/siteverify', [

--- a/src/templates/settings/_recaptcha.html
+++ b/src/templates/settings/_recaptcha.html
@@ -45,20 +45,22 @@
             options: opts,
         }) }}
 
-        {{ forms.textField({
+        {{ forms.autosuggestField({
             label: "reCAPTCHA Site Key"|t('freeform'),
             name: "settings[recaptchaKey]",
             required: true,
             value: settings.recaptchaKey,
             errors: settings.errors("recaptchaKey"),
+            suggestEnvVars: true,
         }) }}
 
-        {{ forms.textField({
+        {{ forms.autosuggestField({
             label: "reCAPTCHA Secret Key"|t('freeform'),
             name: "settings[recaptchaSecret]",
             required: true,
             value: settings.recaptchaSecret,
             errors: settings.errors("recaptchaSecret"),
+            suggestEnvVars: true,
         }) }}
 
         {{ forms.selectField({


### PR DESCRIPTION
If a project is using the project config, the value of `recaptchaKey` and `recaptchaSecret` could be committed when it shouldn't.

These changes make it so the value could be something like `$RECAPTCHA_SECRET_KEY` and the value of the environment variable `RECAPTCHA_SECRET_KEY` would be used.

From testing this out I noticed that the ReCAPTCHA field needs to be readded to the form before using an environment variable, otherwise it will still use the literal value.

I don't believe this would cause any problem for users updating the plugin, since this is the current behavior. But it's something worth mentioning to users who want to switch.

Let me know if I missed any usages of `recaptchaKey` or `recaptchaSecret`.

Here are a couple links with more info

- https://docs.craftcms.com/v3/config/environments.html
- https://docs.craftcms.com/v3/extend/environmental-settings.html