### PR TITLE
Fix Quick Export error

### DIFF
--- a/src/Controllers/Pro/QuickExportController.php
+++ b/src/Controllers/Pro/QuickExportController.php
@@ -56,14 +56,7 @@ class QuickExportController extends BaseController
 
         $firstForm = reset($forms);
 
-        $userId = \Craft::$app->user->getId();
-
-        /** @var ExportSettingRecord $settingRecord */
-        $settingRecord = ExportSettingRecord::findOne(
-            [
-                'userId' => $userId,
-            ]
-        );
+        $settingRecord = $this->getExportSettings();
 
         $setting = [];
         foreach ($forms as $form) {


### PR DESCRIPTION
'freeform_export_settings' table will be empty after restoring with './craft restore/db' command.

So next time I open the 'Quick Export' modal, checkboxes in the field list do not appear.

This commit is a modified code to solve it.

- Craft CMS 3.4.5
- Freeform Pro 3.6.2