### PR TITLE
Update dep stripe-php@v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "hashids/hashids": "^2.0",
     "egulias/email-validator": "^2.1",
     "nesbot/carbon": "^1.22.1|^2.19",
-    "stripe/stripe-php": "^6.6.0",
+    "stripe/stripe-php": "^7.27",
     "phpoffice/phpspreadsheet": "^1.6.0"
   },
   "require-dev": {

--- a/src/Controllers/Pro/Payments/PaymentWebhooksController.php
+++ b/src/Controllers/Pro/Payments/PaymentWebhooksController.php
@@ -43,7 +43,7 @@ class PaymentWebhooksController extends BaseController
             $event = \Stripe\Webhook::constructEvent($payload, $sigHeader, $endpointSecret);
         } catch (\UnexpectedValueException $e) {
             throw new HttpException(400, Freeform::t('Invalid payload'));
-        } catch (\Stripe\Error\SignatureVerification $e) {
+        } catch (\Stripe\Exception\SignatureVerificationException $e) {
             throw new HttpException(400, Freeform::t('Invalid signature'));
         }
 

--- a/src/Services/Pro/Payments/StripeService.php
+++ b/src/Services/Pro/Payments/StripeService.php
@@ -31,7 +31,7 @@ use Solspace\Freeform\Library\Exceptions\Integrations\IntegrationException;
 use Solspace\Freeform\Library\Logging\FreeformLogger;
 use Solspace\Freeform\Models\IntegrationModel;
 use Stripe\Customer;
-use Stripe\Error\Card;
+use Stripe\Exception\CardException as Card;
 use Stripe\Invoice;
 use Stripe\PaymentIntent;
 use Stripe\Plan;


### PR DESCRIPTION
followed migration guide, needed for PHP 7.4 compatibility; probably also necessary if commerce-stripe updates their stripe dependencies (see  [https://github.com/craftcms/commerce-stripe/issues/95](https://github.com/craftcms/commerce-stripe/issues/95))