### PR TITLE
Allowing for stripe description / meta to be edited in config

### DIFF
--- a/src/Integrations/PaymentGateways/Stripe.php
+++ b/src/Integrations/PaymentGateways/Stripe.php
@@ -706,11 +706,17 @@ class Stripe extends AbstractPaymentGatewayIntegration
             }
         }
 
+        $updateDataCallback = Freeform::getInstance()->getSettings()->stripePaymentDataCallback;
+
         try {
-            $updateData = [
-                'description' => 'Payment for FF Submission #' . $submissionId,
-                'metadata'    => ['submissionId' => $submissionId],
-            ];
+            if($updateDataCallback) {
+                $updateData = $updateDataCallback($paymentDetails->getSubmission());
+            } else {
+                $updateData = [
+                    'description' => 'Payment for FF Submission #' . $submissionId,
+                    'metadata'    => ['submissionId' => $submissionId],
+                ];
+            }
 
             if ($customer) {
                 $updateData['customer'] = $customer;

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -190,6 +190,9 @@ class Settings extends Model
     /** @var bool */
     public $hideBannerOldFreeform = false;
 
+    /** @var callable */
+    public $stripePaymentDataCallback = null;
+
     /**
      * Settings constructor.
      *


### PR DESCRIPTION
Here's how I'm using it: 

```php
<?php

return [
    'stripePaymentDataCallback' => function(\Solspace\Freeform\Elements\Submission $submission) {
        return  [
            'description' => 'COTMU | ' . $submission->getForm()->getName(),
            'metadata'    => [
                'submissionId' => $submission->getId(),
                'description' => $submission->getForm()->getDescription()
            ],
        ];
    }
];
```