### PR TITLE
Added `date` as an allowed Hubspot field type

### DIFF
--- a/src/Integrations/CRM/HubSpot.php
+++ b/src/Integrations/CRM/HubSpot.php
@@ -450,6 +450,7 @@ class HubSpot extends AbstractCRMIntegration
                 case 'string':
                 case 'enumeration':
                 case 'datetime':
+                case 'date':
                 case 'phone_number':
                     $type = FieldObject::TYPE_STRING;
                     break;


### PR DESCRIPTION
We ran into an issue where the Hubspot custom field type was created as a `date` field and it would not appear as a mappable field in the CRM Integration tab when editing a Freeform form in the control panel.

The default Hubspot creation date however did appear as a mappable field.

After a closer look at the issue it appears that the Hubspot integration class does not accept a `date` field while it is listed as a valid type (see: https://legacydocs.hubspot.com/docs/methods/crm-properties/crm-properties-overview).

For reference this is the Create Date as it appears in the API call to get Deal properties:

```
    {
        "name": "createdate",
        "label": "Create Date",
        "description": "The date the deal was created. This property is set automatically by HubSpot.",
        "groupName": "dealinformation",
        "type": "datetime",
        "fieldType": "date",
        "searchableInGlobalSearch": false,
        "createdUserId": null,
        "referencedObjectType": null,
        "hasUniqueValue": false,
        "optionSortStrategy": null,
        "numberDisplayHint": null,
        "searchTextAnalysisMode": null,
        "textDisplayHint": null,
        "currencyPropertyName": null,
        "optionsAreMutable": null,
        "isCustomizedDefault": false,
        "updatedUserId": null,
        "hidden": false,
        "formField": false,
        "readOnlyValue": false,
        "readOnlyDefinition": true,
        "mutableDefinitionNotDeletable": false,
        "favorited": true,
        "favoritedOrder": 6,
        "calculated": false,
        "externalOptions": false,
        "displayMode": "current_value",
        "showCurrencySymbol": null,
        "hubspotDefined": true,
        "deleted": null,
        "options": [],
        "createdAt": null,
        "updatedAt": null,
        "displayOrder": 6
    },
```

This is the field that was not being listed as a mappable field:

```
{
        "name": "booking_date",
        "label": "Booking date",
        "description": "Date of booking",
        "groupName": "dealinformation",
        "type": "date",
        "fieldType": "date",
        "searchableInGlobalSearch": false,
        "createdUserId": 1234,
        "referencedObjectType": null,
        "hasUniqueValue": false,
        "optionSortStrategy": null,
        "numberDisplayHint": "formatted",
        "searchTextAnalysisMode": null,
        "textDisplayHint": null,
        "currencyPropertyName": null,
        "optionsAreMutable": null,
        "isCustomizedDefault": false,
        "updatedUserId": 1234,
        "hidden": false,
        "formField": true,
        "readOnlyValue": false,
        "readOnlyDefinition": false,
        "mutableDefinitionNotDeletable": false,
        "favorited": false,
        "favoritedOrder": -1,
        "calculated": false,
        "externalOptions": false,
        "displayMode": "current_value",
        "showCurrencySymbol": false,
        "hubspotDefined": null,
        "deleted": false,
        "options": [],
        "createdAt": 1578354105742,
        "updatedAt": 1595298218036,
        "displayOrder": -1
    },
```
