### PR TITLE
Allow Symfony Filesystem ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "craftcms/cms": "^3.4.0",
     "symfony/property-access": "^2.8|^3.0|^4.0",
     "symfony/finder": "^2.8|^3.0|^4.0",
-    "symfony/filesystem": "^2.8|^3.0|^4.0",
+    "symfony/filesystem": "^2.8|^3.0|^4.0|^5.0",
     "solspace/craft3-commons": "^1.0.21",
     "hashids/hashids": "^2.0",
     "egulias/email-validator": "^2.1",


### PR DESCRIPTION
This version is now indirectly required by Craft 3.5, due to a `composer/composer` requirement.

No found usages of either changed methods in `symfony/filesystem`.

**Refs:**

- [symfony/filesystem/blob/master/CHANGELOG.md#500](https://github.com/symfony/filesystem/blob/master/CHANGELOG.md#500)