### PR TITLE
Check empty getAllowedSubmissionFormIds() return

### DIFF
--- a/src/Elements/Submission.php
+++ b/src/Elements/Submission.php
@@ -207,7 +207,7 @@ class Submission extends Element
             $forms        = $formsService->getAllForms();
 
             $allowedFormIds = Freeform::getInstance()->submissions->getAllowedSubmissionFormIds();
-            if ($isAdmin) {
+            if ($isAdmin || $allowedFormIds === null) {
                 $allowedFormIds = array_keys($forms);
             }
 


### PR DESCRIPTION
`getAllowedSubmissionFormIds()` can be null in case the user has access to all forms.
https://github.com/solspace/craft3-freeform/blob/e52a1da0be90ee057387c9abd5acb2ad21615b26/src/Services/SubmissionsService.php#L438-L452

This causes an error here:
https://github.com/solspace/craft3-freeform/blob/e52a1da0be90ee057387c9abd5acb2ad21615b26/src/Elements/Submission.php#L224



Error reproduction can be done using these permissions:
![image](https://user-images.githubusercontent.com/1143308/90158637-8898d280-dd8f-11ea-853f-0608da326fcc.png)
