### PR TITLE
Add multiselectpicklist as a Zoho Lead field type

### DIFF
--- a/src/Integrations/CRM/Zoho/AbstractZohoIntegration.php
+++ b/src/Integrations/CRM/Zoho/AbstractZohoIntegration.php
@@ -369,13 +369,14 @@ abstract class AbstractZohoIntegration extends CRMOAuthConnector
 
             case 'list':
             case 'picklist':
-
-                if ($jsonType == 'jsonobject') {
+            case 'multiselectpicklist':
+                
+                if ($jsonType == 'jsonobject' || $jsonType == 'jsonarray') {
                     $type = FieldObject::TYPE_ARRAY;
                 } else {
                     $type = FieldObject::TYPE_STRING;
                 }
-
+                
                 break;
 
             case 'integer':


### PR DESCRIPTION
Add multiselectpicklist as a Zoho Lead field type + configure to be sent as an array instead of falling back to be sent as a string