### PR TITLE
Add support for Twig in admin recipients field

### DIFF
--- a/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
+++ b/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
@@ -39,7 +39,7 @@ class AdminNotificationProperties extends AbstractProperties
     /**
      * Gets all recipients as an array.
      */
-    public function getRecipientArray($submission = null): array
+    public function getRecipientArray(Submission $submission = null): array
     {
         $recipients = $this->getRecipients();
 

--- a/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
+++ b/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
@@ -39,9 +39,18 @@ class AdminNotificationProperties extends AbstractProperties
     /**
      * Gets all recipients as an array.
      */
-    public function getRecipientArray(): array
+    public function getRecipientArray($submission = null): array
     {
         $recipients = $this->getRecipients();
+
+        // Handle any Twig used in the recipients, and swallow any errors
+        if ($submission) {
+            try {
+                $recipients = \Craft::$app->getView()->renderString($recipients, $submission->toArray());
+            } catch (\Throwable $e) {
+
+            }
+        }
 
         if (empty($recipients)) {
             return [];

--- a/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
+++ b/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
@@ -48,7 +48,6 @@ class AdminNotificationProperties extends AbstractProperties
             try {
                 $recipients = \Craft::$app->getView()->renderString($recipients, $submission->toArray());
             } catch (\Throwable $e) {
-
             }
         }
 

--- a/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
+++ b/packages/plugin/src/Library/Composer/Components/Properties/AdminNotificationProperties.php
@@ -12,6 +12,8 @@
 
 namespace Solspace\Freeform\Library\Composer\Components\Properties;
 
+use Solspace\Freeform\Elements\Submission;
+
 class AdminNotificationProperties extends AbstractProperties
 {
     /** @var int */

--- a/packages/plugin/src/Services/IntegrationsService.php
+++ b/packages/plugin/src/Services/IntegrationsService.php
@@ -133,7 +133,7 @@ class IntegrationsService extends BaseService
         if (!$suppressors->isAdminNotifications() && $adminNotifications->getNotificationId()) {
             $mailer->sendEmail(
                 $form,
-                $adminNotifications->getRecipientArray(),
+                $adminNotifications->getRecipientArray($submission),
                 $adminNotifications->getNotificationId(),
                 $fields,
                 $submission


### PR DESCRIPTION
A client of ours requires the use of Twig in the Admin Recipients field, so allow them to setup custom (complex) logic to add recipients based on a number of different field values. This PR adds Twig-parsing of submission variables.

This was achievable through the `EVENT_BEFORE_SEND` event in the Craft 2 version of Freeform, but this Craft 3 version doesn't support the ability to modify the recipients, as they're already processed before reaching the event trigger, and can't be modified.