### PR TITLE
updated Sharpspring crm integration, custom fields did not show up in cms

### DIFF
--- a/packages/plugin/src/Integrations/CRM/SharpSpring.php
+++ b/packages/plugin/src/Integrations/CRM/SharpSpring.php
@@ -133,7 +133,7 @@ class SharpSpring extends AbstractCRMIntegration
      */
     public function fetchFields(): array
     {
-        $response = $this->getResponse($this->generatePayload('getFields'));
+        $response = $this->getResponse($this->generatePayload('getFields', ['isCustom' => "1"]));
         $data = json_decode((string) $response->getBody(), true);
 
         $fields = [];
@@ -168,7 +168,9 @@ class SharpSpring extends AbstractCRMIntegration
         ];
 
         foreach ($fields as $field) {
-            if (!$field || !\is_object($field) || $field->readOnlyValue || $field->hidden || $field->calculated) {
+            
+            $field = (object)$field;
+            if (!$field || !\is_object($field)) {
                 continue;
             }
 


### PR DESCRIPTION
Recently tested the SharpSpring CRM integration in the cms of the website of our company and noticed the SharpSpring custom fields didn't show up.
It appears that the sharpspring api has changed, the method 'getFields' returns all the fields including the standard fields.
Show we can add the 'isCustom = 1' filter in the api request.
Next, the properties 'hidden', 'readonlyvalue', 'calculated' do not exist anymore.
Also the $field object wasn't casted to an object which triggered the first condition and resulted in an empty list instead of all the custom fields.