### PR TITLE
Fixed loading custom fields for sharpspring

### DIFF
--- a/packages/plugin/src/Integrations/CRM/SharpSpring.php
+++ b/packages/plugin/src/Integrations/CRM/SharpSpring.php
@@ -133,12 +133,12 @@ class SharpSpring extends AbstractCRMIntegration
      */
     public function fetchFields(): array
     {
-        $response = $this->getResponse($this->generatePayload('getFields', ['isCustom' => "1"]));
-        $data = json_decode((string) $response->getBody(), true);
-
+        $response = $this->getResponse($this->generatePayload('getFields', ['where' => ['isCustom' => '1']]));
+        $json = (string) $response->getBody();
+        $data = json_decode($json, true);
         $fields = [];
         if (isset($data['result']['field'])) {
-            $fields = $data['result']['field'];
+           $fields = $data['result']['field'];
         }
 
         $suffix = ' (Contact)';


### PR DESCRIPTION
The issue presented by @arnevanbael-axxes in PR #198 hadn't been fully fixed due to not putting "isCustom" in the "where" clause. Fully tested in a dev environment on Craft CMS. This fixes the issue.