### PR TITLE
Wrapped field definitions in TypeManager::prepareFieldDefinitions

### DIFF
--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/FieldInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/FieldInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects\KeyValueMapInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\FieldType;
@@ -31,7 +32,7 @@ class FieldInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'id' => [
                 'name' => 'id',
                 'type' => Type::int(),
@@ -92,6 +93,6 @@ class FieldInterface extends AbstractInterface
                 'type' => Type::listOf(KeyValueMapInterface::getType()),
                 'description' => "Field's instruction attributes",
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/FormInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/FormInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Arguments\FieldArguments;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects\CsrfTokenInterface;
@@ -37,7 +38,7 @@ class FormInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'id' => [
                 'name' => 'id',
                 'type' => Type::int(),
@@ -194,6 +195,6 @@ class FormInterface extends AbstractInterface
                 'args' => FieldArguments::getArguments(),
                 'description' => "Form's fields",
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/FreeformInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/FreeformInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Arguments\FormArguments;
 use Solspace\Freeform\Bundles\GraphQL\Resolvers\FormResolver;
@@ -32,7 +33,7 @@ class FreeformInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'version' => [
                 'name' => 'version',
                 'type' => Type::string(),
@@ -52,6 +53,6 @@ class FreeformInterface extends AbstractInterface
                 'args' => FormArguments::getArguments(),
                 'description' => 'Freeform forms',
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/PageInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/PageInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\PageGenerator;
 use Solspace\Freeform\Bundles\GraphQL\Types\PageType;
@@ -30,7 +31,7 @@ class PageInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'index' => [
                 'name' => 'index',
                 'type' => Type::int(),
@@ -47,6 +48,6 @@ class PageInterface extends AbstractInterface
                 'type' => Type::listOf(RowInterface::getType()),
                 'description' => "Page's rows",
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/RowInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/RowInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Arguments\FieldArguments;
 use Solspace\Freeform\Bundles\GraphQL\Resolvers\FieldResolver;
@@ -32,7 +33,7 @@ class RowInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'id' => [
                 'name' => 'id',
                 'type' => Type::string(),
@@ -45,6 +46,6 @@ class RowInterface extends AbstractInterface
                 'args' => FieldArguments::getArguments(),
                 'description' => "Row's fields",
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/CsrfTokenInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/CsrfTokenInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\AbstractInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\SimpleObjects\CsrfTokenGenerator;
@@ -31,7 +32,7 @@ class CsrfTokenInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'name' => [
                 'name' => 'name',
                 'type' => Type::string(),
@@ -42,6 +43,6 @@ class CsrfTokenInterface extends AbstractInterface
                 'type' => Type::string(),
                 'description' => 'Value of the CSRF Token',
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/HoneypotInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/HoneypotInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\AbstractInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\SimpleObjects\HoneypotGenerator;
@@ -31,7 +32,7 @@ class HoneypotInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'name' => [
                 'name' => 'name',
                 'type' => Type::string(),
@@ -47,6 +48,6 @@ class HoneypotInterface extends AbstractInterface
                 'type' => Type::int(),
                 'description' => 'Timstamp of the creation date',
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/KeyValueMapInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/KeyValueMapInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\AbstractInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\SimpleObjects\KeyValueMapGenerator;
@@ -31,7 +32,7 @@ class KeyValueMapInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'key' => [
                 'name' => 'key',
                 'type' => Type::string(),
@@ -42,6 +43,6 @@ class KeyValueMapInterface extends AbstractInterface
                 'type' => Type::string(),
                 'description' => 'The value',
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/OptionsInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/OptionsInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\AbstractInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\SimpleObjects\OptionsGenerator;
@@ -31,7 +32,7 @@ class OptionsInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'value' => [
                 'name' => 'value',
                 'type' => Type::string(),
@@ -47,6 +48,6 @@ class OptionsInterface extends AbstractInterface
                 'type' => Type::boolean(),
                 'description' => 'Is the option checked',
             ],
-        ];
+        ], static::getName());
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/ScalesInterface.php
+++ b/packages/plugin/src/Bundles/GraphQL/Interfaces/SimpleObjects/ScalesInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\GraphQL\Interfaces\SimpleObjects;
 
+use craft\gql\TypeManager;
 use GraphQL\Type\Definition\Type;
 use Solspace\Freeform\Bundles\GraphQL\Interfaces\AbstractInterface;
 use Solspace\Freeform\Bundles\GraphQL\Types\Generators\SimpleObjects\ScalesGenerator;
@@ -31,7 +32,7 @@ class ScalesInterface extends AbstractInterface
 
     public static function getFieldDefinitions(): array
     {
-        return [
+        return TypeManager::prepareFieldDefinitions([
             'value' => [
                 'name' => 'value',
                 'type' => Type::string(),
@@ -42,6 +43,6 @@ class ScalesInterface extends AbstractInterface
                 'type' => Type::string(),
                 'description' => 'Label',
             ],
-        ];
+        ], static::getName());
     }
 }


### PR DESCRIPTION
The Craft CMS docs state that _["When adding fields to a given type, you should run them through craft\gql\TypeManager::prepareFieldDefinitions(). This makes it possible for others to programmatically modify type fields you’re introducing."](https://craftcms.com/docs/3.x/extend/graphql.html#types)_

This PR wraps the type interfaces in `TypeManager::prepareFieldDefinitions`, which allows others to extend the GraphQL types as per the [modifying type fields](https://craftcms.com/docs/3.x/extend/graphql.html#modifying-type-fields) docs. A first-party example is available in the [`craft\commerce\gql\interfaces\elements\Product`](https://github.com/craftcms/commerce/blob/develop/src/gql/interfaces/elements/Product.php) type.

As a use-case example, the following is a snippet for an example module or plugin which adds an HTML string to the forms:

```php
Event::on(
    TypeManager::class,
    TypeManager::EVENT_DEFINE_GQL_TYPE_FIELDS,
    function (DefineGqlTypeFieldsEvent $event) {
        if ($event->typeName === 'FreeformFormInterface') {
            $event->fields['html'] = [
                'name' => 'html',
                'type' => Type::string(),
                'resolve' => function (Form $source, array $arguments, $context, ResolveInfo $resolveInfo) {
                    return $source->render();
                }
            ];
        }

        return $event;
    }
);
```