### PR TITLE
[SFT-9]: Deleting thousands of submissions runs out of memory

### DIFF
--- a/packages/plugin/src/Controllers/SpamSubmissionsController.php
+++ b/packages/plugin/src/Controllers/SpamSubmissionsController.php
@@ -13,6 +13,7 @@
 namespace Solspace\Freeform\Controllers;
 
 use Solspace\Commons\Helpers\PermissionHelper;
+use Solspace\Freeform\Elements\Submission;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\Exceptions\FreeformException;
 use Solspace\Freeform\Services\SubmissionsService;
@@ -32,11 +33,7 @@ class SpamSubmissionsController extends SubmissionsController
         $this->requirePostRequest();
 
         $id = $this->request->post('id');
-        $submission = $this->getSubmissionsService()->getSubmissionById($id);
-
-        if ($submission) {
-            $this->getSubmissionsService()->delete([$submission]);
-        }
+        $this->getSubmissionsService()->delete(Submission::find()->id($id));
 
         return $this->asJson(['success' => true]);
     }

--- a/packages/plugin/src/Elements/Actions/DeleteAllSubmissionsAction.php
+++ b/packages/plugin/src/Elements/Actions/DeleteAllSubmissionsAction.php
@@ -31,7 +31,7 @@ class DeleteAllSubmissionsAction extends ElementAction
     {
         $query->id(null);
 
-        Freeform::getInstance()->submissions->delete($query->all());
+        Freeform::getInstance()->submissions->delete($query);
 
         $this->setMessage($this->successMessage);
 

--- a/packages/plugin/src/Elements/Actions/DeleteSubmissionAction.php
+++ b/packages/plugin/src/Elements/Actions/DeleteSubmissionAction.php
@@ -9,9 +9,9 @@ use Solspace\Freeform\Freeform;
 
 class DeleteSubmissionAction extends ElementAction implements DeleteActionInterface
 {
-    public string $confirmationMessage;
+    public null|string $confirmationMessage = null;
 
-    public string $successMessage;
+    public null|string $successMessage = null;
 
     public bool $hard = false;
 
@@ -46,7 +46,7 @@ class DeleteSubmissionAction extends ElementAction implements DeleteActionInterf
 
     public function performAction(ElementQueryInterface $query): bool
     {
-        Freeform::getInstance()->submissions->delete($query->all(), false, $this->hard);
+        Freeform::getInstance()->submissions->delete($query, false, $this->hard);
 
         $this->setMessage($this->successMessage);
 

--- a/packages/plugin/src/Variables/FreeformVariable.php
+++ b/packages/plugin/src/Variables/FreeformVariable.php
@@ -96,12 +96,9 @@ class FreeformVariable
             return false;
         }
 
-        $submission = Submission::findOne(['token' => $token]);
-        if ($submission) {
-            return Freeform::getInstance()->submissions->delete([$submission], true);
-        }
+        $query = Submission::find()->limit(1)->token($token);
 
-        return false;
+        return Freeform::getInstance()->submissions->delete($query, true);
     }
 
     public function getSettings(): Settings


### PR DESCRIPTION
Adresses issue #485

* fixed PHP running out of memory when deleting thousands of submissions at once by refactoring the delete process to use batching