### PR TITLE
[SFT-26]: Add validators to properties via PHP attributes

### DIFF
--- a/packages/plugin/src/Attributes/Property/Validator.php
+++ b/packages/plugin/src/Attributes/Property/Validator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Solspace\Freeform\Attributes\Property;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+abstract class Validator implements ValidatorInterface
+{
+}

--- a/packages/plugin/src/Attributes/Property/ValidatorInterface.php
+++ b/packages/plugin/src/Attributes/Property/ValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Solspace\Freeform\Attributes\Property;
+
+use Solspace\Freeform\Library\Composer\Components\FieldInterface;
+
+interface ValidatorInterface
+{
+    public function validate(FieldInterface $field, mixed $value): bool;
+}

--- a/packages/plugin/src/Attributes/Property/Validators/HandleValidator.php
+++ b/packages/plugin/src/Attributes/Property/Validators/HandleValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Solspace\Freeform\Attributes\Property\Validators;
+
+use Solspace\Freeform\Attributes\Property\Validator;
+use Solspace\Freeform\Library\Composer\Components\FieldInterface;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+class HandleValidator extends Validator
+{
+    public function __construct(
+        private string $message = 'Value is not a valid handle.',
+    ) {
+    }
+
+    public function validate(FieldInterface $field, mixed $value): bool
+    {
+        // TODO: implement handle validator logic
+        $field->addError($this->message);
+
+        return false;
+    }
+}

--- a/packages/plugin/src/Attributes/Property/Validators/LengthValidator.php
+++ b/packages/plugin/src/Attributes/Property/Validators/LengthValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Solspace\Freeform\Attributes\Property\Validators;
+
+use Solspace\Commons\Helpers\StringHelper;
+use Solspace\Freeform\Attributes\Property\Validator;
+use Solspace\Freeform\Library\Composer\Components\FieldInterface;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+class LengthValidator extends Validator
+{
+    public function __construct(
+        private int $length = 255,
+        private string $message = 'Value contains {current} characters, {max} allowed.',
+    ) {
+    }
+
+    public function validate(FieldInterface $field, mixed $value): bool
+    {
+        $currentLength = \strlen($value);
+
+        if ($currentLength <= $this->length) {
+            return true;
+        }
+
+        $message = StringHelper::replaceValues(
+            $this->message,
+            [
+                'current' => $currentLength,
+                'max' => $this->length,
+            ]
+        );
+
+        $field->addError($message);
+
+        return false;
+    }
+}

--- a/packages/plugin/src/Library/Composer/Components/AbstractField.php
+++ b/packages/plugin/src/Library/Composer/Components/AbstractField.php
@@ -48,7 +48,7 @@ abstract class AbstractField implements FieldInterface, \JsonSerializable
         order: 2,
         placeholder: 'myField',
     )]
-    #[Middleware('handle', ['label'])]
+    #[Middleware('handle')]
     #[Flag('code')]
     #[HandleValidator]
     #[LengthValidator(100)]

--- a/packages/plugin/src/Library/Composer/Components/AbstractField.php
+++ b/packages/plugin/src/Library/Composer/Components/AbstractField.php
@@ -18,6 +18,8 @@ use Solspace\Freeform\Attributes\Property\Flag;
 use Solspace\Freeform\Attributes\Property\Middleware;
 use Solspace\Freeform\Attributes\Property\Property;
 use Solspace\Freeform\Attributes\Property\Section;
+use Solspace\Freeform\Attributes\Property\Validators\HandleValidator;
+use Solspace\Freeform\Attributes\Property\Validators\LengthValidator;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use Solspace\Freeform\Library\Composer\Components\Attributes\CustomFieldAttributes;
@@ -48,6 +50,8 @@ abstract class AbstractField implements FieldInterface, \JsonSerializable
     )]
     #[Middleware('handle', ['label'])]
     #[Flag('code')]
+    #[HandleValidator]
+    #[LengthValidator(100)]
     protected string $handle = '';
 
     #[Section('general')]

--- a/packages/plugin/tests/Unit/Attributes/Property/Validators/LengthValidatorTest.php
+++ b/packages/plugin/tests/Unit/Attributes/Property/Validators/LengthValidatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Solspace\Tests\Freeform\Unit\Attributes\Property\Validators;
+
+use PHPUnit\Framework\TestCase;
+use Solspace\Freeform\Attributes\Property\Validators\LengthValidator;
+use Solspace\Freeform\Library\Composer\Components\FieldInterface;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class LengthValidatorTest extends TestCase
+{
+    public function testValidOnSameLength()
+    {
+        $validator = new LengthValidator(100);
+
+        $mock = $this->createMock(FieldInterface::class);
+        $mock
+            ->expects($this->never())
+            ->method('addError')
+        ;
+
+        $value = str_repeat('.', 100);
+
+        $result = $validator->validate($mock, $value);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidOnSmallerLength()
+    {
+        $validator = new LengthValidator(100);
+
+        $mock = $this->createMock(FieldInterface::class);
+        $mock
+            ->expects($this->never())
+            ->method('addError')
+        ;
+
+        $value = str_repeat('.', 99);
+
+        $result = $validator->validate($mock, $value);
+
+        $this->assertTrue($result);
+    }
+
+    public function testInvalidOnLargerLength()
+    {
+        $validator = new LengthValidator(100);
+
+        $mock = $this->createMock(FieldInterface::class);
+        $mock
+            ->expects($this->once())
+            ->method('addError')
+            ->with('Value contains 101 characters, 100 allowed.')
+        ;
+
+        $value = str_repeat('.', 101);
+
+        $result = $validator->validate($mock, $value);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCustomErrorMessage()
+    {
+        $validator = new LengthValidator(
+            100,
+            'This is max {max}, This is current {current}, this is max {max}'
+        );
+
+        $array = ['one', 'two', 'three'];
+
+        $mock = $this->createMock(FieldInterface::class);
+        $mock
+            ->expects($this->once())
+            ->method('addError')
+            ->with('This is max 100, This is current 101, this is max 100')
+        ;
+
+        $value = str_repeat('.', 101);
+
+        $result = $validator->validate($mock, $value);
+
+        $this->assertFalse($result);
+    }
+
+    public function testDefaultsTo255()
+    {
+        $validator = new LengthValidator();
+
+        $mock = $this->createMock(FieldInterface::class);
+        $mock
+            ->expects($this->once())
+            ->method('addError')
+            ->with('Value contains 256 characters, 255 allowed.')
+        ;
+
+        $value = str_repeat('.', 256);
+
+        $result = $validator->validate($mock, $value);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
* added `ValidatorInterface` for validator attributes
* added a `#[HandleValidator]` placeholder attribute
* added a `#[LengthValidator]` attribute
* added tests for the `#[LengthValidator]`