### PR TITLE
Fix an issue with custom table attributes firing on all element types

### DIFF
--- a/packages/plugin/src/Bundles/Submissions/CustomSourceFields.php
+++ b/packages/plugin/src/Bundles/Submissions/CustomSourceFields.php
@@ -25,7 +25,7 @@ class CustomSourceFields extends FeatureBundle
 
     public function handleCustomTableAttributes(DefineSourceTableAttributesEvent $event): void
     {
-        if (\in_array($event->elementType, [Submission::class, SpamSubmission::class, true])) {
+        if (\in_array($event->elementType, [Submission::class, SpamSubmission::class], true)) {
             static $forms;
             if (null === $forms) {
                 $forms = Freeform::getInstance()->forms->getAllForms();


### PR DESCRIPTION
Hey crew, 

This seems to be incorrect, and throws an error with Formie's submissions - although it's also not great that this logic fires on **all** element indexes, not just `Submission` and `SpamSubmission` elements. It's only really an issue with Formie because we also use the prefix `form:`, most other element indexes won't be an issue.

This is because you're checking if the current element type is in an array `[Submission::class, SpamSubmission::class, true]` with `true` being always true, it'll always match. Looking at the rest of your code, I assume you're wanting to use the `strict` argument for `in_array`.

Cheers!