### PR TITLE
[SFT-239]: When using Database Table session context, submitting a form gives this error: "Call to a member function getFormId() on null"

### DIFF
--- a/packages/plugin/src/Bundles/Form/Context/Session/StorageTypes/DatabaseStorage.php
+++ b/packages/plugin/src/Bundles/Form/Context/Session/StorageTypes/DatabaseStorage.php
@@ -67,6 +67,10 @@ class DatabaseStorage implements FormContextStorageInterface
         ;
 
         foreach ($this->context as $key => $bag) {
+            if (null === $bag) {
+                continue;
+            }
+
             $isNew = !\in_array($key, $existingKeys, true);
 
             $payload = [


### PR DESCRIPTION
* fixed database context cleanup issue