### PR TITLE
[SFT-280] - Include template autosuggest to relevant Freeform path settings in CP

### DIFF
--- a/packages/plugin/src/Variables/FreeformVariable.php
+++ b/packages/plugin/src/Variables/FreeformVariable.php
@@ -209,19 +209,21 @@ class FreeformVariable
     {
         $this->siteTemplatesDirectories = [];
 
-        $this->getSiteTemplatesDirectories(\Craft::$app->getPath()->getSiteTemplatesPath());
+        $siteTemplatesPath = \Craft::$app->getPath()->getSiteTemplatesPath();
+
+        $this->getSiteTemplatesDirectories($siteTemplatesPath, $siteTemplatesPath);
 
         return $this->siteTemplatesDirectories;
     }
 
-    private function getSiteTemplatesDirectories(string $path): void
+    private function getSiteTemplatesDirectories(string $siteTemplatesPath, string $currentPath): void
     {
-        foreach (new \DirectoryIterator($path) as $fileInfo) {
+        foreach (new \DirectoryIterator($currentPath) as $fileInfo) {
             if (!$fileInfo->isDot()) {
                 if ($fileInfo->isDir()) {
-                    $this->siteTemplatesDirectories[] = $fileInfo->getPathname();
+                    $this->siteTemplatesDirectories[] = str_replace($siteTemplatesPath, '', $fileInfo->getPathname());
 
-                    $this->getSiteTemplatesDirectories($fileInfo->getPathname());
+                    $this->getSiteTemplatesDirectories($siteTemplatesPath, $fileInfo->getPathname());
                 }
             }
         }

--- a/packages/plugin/src/Variables/FreeformVariable.php
+++ b/packages/plugin/src/Variables/FreeformVariable.php
@@ -221,7 +221,7 @@ class FreeformVariable
         foreach (new \DirectoryIterator($currentPath) as $fileInfo) {
             if (!$fileInfo->isDot()) {
                 if ($fileInfo->isDir()) {
-                    $this->siteTemplatesDirectories[] = str_replace($siteTemplatesPath, '', $fileInfo->getPathname());
+                    $this->siteTemplatesDirectories[] = str_replace($siteTemplatesPath.'/', '', $fileInfo->getPathname());
 
                     $this->getSiteTemplatesDirectories($siteTemplatesPath, $fileInfo->getPathname());
                 }

--- a/packages/plugin/src/Variables/FreeformVariable.php
+++ b/packages/plugin/src/Variables/FreeformVariable.php
@@ -32,6 +32,8 @@ use Twig\Markup;
 
 class FreeformVariable
 {
+    public array $siteTemplatesDirectories = [];
+
     /**
      * @param int|string $handleOrId
      *
@@ -201,6 +203,28 @@ class FreeformVariable
     public function notifications(): NotificationsService
     {
         return Freeform::getInstance()->notifications;
+    }
+
+    public function getAllSiteTemplatesDirectories(): array
+    {
+        $this->siteTemplatesDirectories = [];
+
+        $this->getSiteTemplatesDirectories(\Craft::$app->getPath()->getSiteTemplatesPath());
+
+        return $this->siteTemplatesDirectories;
+    }
+
+    private function getSiteTemplatesDirectories(string $path): void
+    {
+        foreach (new \DirectoryIterator($path) as $fileInfo) {
+            if (!$fileInfo->isDot()) {
+                if ($fileInfo->isDir()) {
+                    $this->siteTemplatesDirectories[] = $fileInfo->getPathname();
+
+                    $this->getSiteTemplatesDirectories($fileInfo->getPathname());
+                }
+            }
+        }
     }
 
     private function getFormService(): FormsService

--- a/packages/plugin/src/templates/settings/_email-templates.twig
+++ b/packages/plugin/src/templates/settings/_email-templates.twig
@@ -68,7 +68,7 @@
                 "data": suggestionsData
             }],
             tip: null,
-            limit: 9999,
+            limit: 10,
             name: "settings[emailTemplateDirectory]",
             value: settings.emailTemplateDirectory,
             errors: settings.getErrors("emailTemplateDirectory"),

--- a/packages/plugin/src/templates/settings/_email-templates.twig
+++ b/packages/plugin/src/templates/settings/_email-templates.twig
@@ -73,7 +73,7 @@
             value: settings.emailTemplateDirectory,
             errors: settings.getErrors("emailTemplateDirectory"),
             instructions: "Provide a relative path to the Craft Templates folder where your email templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your email formatting and allows Freeform to locate these files when setting up notifications."|t('freeform'),
-            placeholder: "e.g. _freeform_emails/",
+            placeholder: "e.g. _freeform/notifications",
         }) }}
 
         {% if settings.absoluteEmailTemplateDirectory %}

--- a/packages/plugin/src/templates/settings/_email-templates.twig
+++ b/packages/plugin/src/templates/settings/_email-templates.twig
@@ -64,7 +64,7 @@
             suggestEnvVars: false,
             suggestAliases: false,
             suggestions:[{
-                "label":"Site Templates",
+                "label":"Existing Directories",
                 "data": suggestionsData
             }],
             tip: null,

--- a/packages/plugin/src/templates/settings/_email-templates.twig
+++ b/packages/plugin/src/templates/settings/_email-templates.twig
@@ -50,15 +50,30 @@
             errors: settings.errors("allowFileTemplateEdit"),
         }) }}
 
-        {{ forms.textField({
-            class: "code",
+        {% set suggestionsData = [] %}
+        {% for directory in craft.freeform.getAllSiteTemplatesDirectories() %}
+            {% set suggestionsData = suggestionsData|merge([{
+                "name": directory
+            }]) %}
+        {% endfor %}
+
+        {{ forms.autosuggestField({
             label: "File Directory Path"|t('freeform'),
-            instructions: "Provide a relative path to the Craft Templates folder where your email templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your email formatting and allows Freeform to locate these files when setting up notifications."|t('freeform'),
-            placeholder: "e.g. _freeform_emails/",
             id: "emailTemplateDirectory",
+            class: "ltr",
+            suggestEnvVars: false,
+            suggestAliases: false,
+            suggestions:[{
+                "label":"Site Templates",
+                "data": suggestionsData
+            }],
+            tip: null,
+            limit: 9999,
             name: "settings[emailTemplateDirectory]",
             value: settings.emailTemplateDirectory,
             errors: settings.getErrors("emailTemplateDirectory"),
+            instructions: "Provide a relative path to the Craft Templates folder where your email templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your email formatting and allows Freeform to locate these files when setting up notifications."|t('freeform'),
+            placeholder: "e.g. _freeform_emails/",
         }) }}
 
         {% if settings.absoluteEmailTemplateDirectory %}

--- a/packages/plugin/src/templates/settings/_formatting-templates.html
+++ b/packages/plugin/src/templates/settings/_formatting-templates.html
@@ -26,7 +26,7 @@
         suggestEnvVars: false,
         suggestAliases: false,
         suggestions:[{
-            "label":"Site Templates",
+            "label":"Existing Directories",
             "data": suggestionsData
         }],
         tip: null,

--- a/packages/plugin/src/templates/settings/_formatting-templates.html
+++ b/packages/plugin/src/templates/settings/_formatting-templates.html
@@ -12,15 +12,30 @@
 
     <h2 class="first">{{ "Formatting Templates"|t('freeform') }}</h2>
 
-    {{ forms.textField({
-        class: "code",
+    {% set suggestionsData = [] %}
+    {% for directory in craft.freeform.getAllSiteTemplatesDirectories() %}
+        {% set suggestionsData = suggestionsData|merge([{
+            "name": directory
+        }]) %}
+    {% endfor %}
+
+    {{ forms.autosuggestField({
         label: "Directory Path"|t('freeform'),
-        instructions: "Provide a relative path to the Craft Templates folder where your custom formatting templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your form formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
-        placeholder: "e.g. _freeform_formatting/",
         id: "formTemplateDirectory",
+        class: "ltr",
+        suggestEnvVars: false,
+        suggestAliases: false,
+        suggestions:[{
+            "label":"Site Templates",
+            "data": suggestionsData
+        }],
+        tip: null,
+        limit: 9999,
         name: "settings[formTemplateDirectory]",
         value: settings.formTemplateDirectory,
         errors: settings.getErrors("formTemplateDirectory"),
+        instructions: "Provide a relative path to the Craft Templates folder where your custom formatting templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your form formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
+        placeholder: "e.g. _freeform_formatting/",
     }) }}
 
     {% if settings.absoluteFormTemplateDirectory %}

--- a/packages/plugin/src/templates/settings/_formatting-templates.html
+++ b/packages/plugin/src/templates/settings/_formatting-templates.html
@@ -35,7 +35,7 @@
         value: settings.formTemplateDirectory,
         errors: settings.getErrors("formTemplateDirectory"),
         instructions: "Provide a relative path to the Craft Templates folder where your custom formatting templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your form formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
-        placeholder: "e.g. _freeform_formatting/",
+        placeholder: "e.g. _freeform/formatting",
     }) }}
 
     {% if settings.absoluteFormTemplateDirectory %}

--- a/packages/plugin/src/templates/settings/_formatting-templates.html
+++ b/packages/plugin/src/templates/settings/_formatting-templates.html
@@ -30,7 +30,7 @@
             "data": suggestionsData
         }],
         tip: null,
-        limit: 9999,
+        limit: 10,
         name: "settings[formTemplateDirectory]",
         value: settings.formTemplateDirectory,
         errors: settings.getErrors("formTemplateDirectory"),

--- a/packages/plugin/src/templates/settings/_success-templates.html
+++ b/packages/plugin/src/templates/settings/_success-templates.html
@@ -35,7 +35,7 @@
         value: settings.successTemplateDirectory,
         errors: settings.getErrors("successTemplateDirectory"),
         instructions: "Provide a relative path to the Craft Templates folder where your success templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your success formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
-        placeholder: "e.g. _freeform_success/",
+        placeholder: "e.g. _freeform/success",
     }) }}
 
     {% if settings.absoluteSuccessTemplateDirectory %}

--- a/packages/plugin/src/templates/settings/_success-templates.html
+++ b/packages/plugin/src/templates/settings/_success-templates.html
@@ -30,7 +30,7 @@
             "data": suggestionsData
         }],
         tip: null,
-        limit: 9999,
+        limit: 10,
         name: "settings[successTemplateDirectory]",
         value: settings.successTemplateDirectory,
         errors: settings.getErrors("successTemplateDirectory"),

--- a/packages/plugin/src/templates/settings/_success-templates.html
+++ b/packages/plugin/src/templates/settings/_success-templates.html
@@ -26,7 +26,7 @@
         suggestEnvVars: false,
         suggestAliases: false,
         suggestions:[{
-            "label":"Site Templates",
+            "label":"Existing Directories",
             "data": suggestionsData
         }],
         tip: null,

--- a/packages/plugin/src/templates/settings/_success-templates.html
+++ b/packages/plugin/src/templates/settings/_success-templates.html
@@ -12,15 +12,30 @@
 
     <h2 class="first">{{ "Success Templates"|t('freeform') }}</h2>
 
-    {{ forms.textField({
-        class: "code",
+    {% set suggestionsData = [] %}
+    {% for directory in craft.freeform.getAllSiteTemplatesDirectories() %}
+        {% set suggestionsData = suggestionsData|merge([{
+            "name": directory
+        }]) %}
+    {% endfor %}
+
+    {{ forms.autosuggestField({
         label: "Directory Path"|t('freeform'),
-        instructions: "Provide a relative path to the Craft Templates folder where your success templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your success formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
-        placeholder: "e.g. _freeform_success/",
         id: "successTemplateDirectory",
+        class: "ltr",
+        suggestEnvVars: false,
+        suggestAliases: false,
+        suggestions:[{
+            "label":"Site Templates",
+            "data": suggestionsData
+        }],
+        tip: null,
+        limit: 9999,
         name: "settings[successTemplateDirectory]",
         value: settings.successTemplateDirectory,
         errors: settings.getErrors("successTemplateDirectory"),
+        instructions: "Provide a relative path to the Craft Templates folder where your success templates directory is. If you have not yet created the directory, please do that before filling in this setting. This allows you to use Twig template files for your success formatting and allows Freeform to locate these files when assigning to a form."|t('freeform'),
+        placeholder: "e.g. _freeform_success/",
     }) }}
 
     {% if settings.absoluteSuccessTemplateDirectory %}


### PR DESCRIPTION
- Replaced text field with auto suggest field for email, formatting and success template paths
- Added helper function to list all directories within craft site templates folder