### PR TITLE
[SFT-412] - The automatic Submission Purge feature removes submissions, but does not seem to delete associated Asset files (#706)

### DIFF
--- a/packages/plugin/src/Services/SubmissionsService.php
+++ b/packages/plugin/src/Services/SubmissionsService.php
@@ -512,6 +512,7 @@ class SubmissionsService extends BaseService implements SubmissionHandlerInterfa
 
         $query = $this->getFindQuery()
             ->id($ids)
+            ->skipContent(true)
         ;
 
         $count = $query->count();

--- a/packages/plugin/src/Services/SubmissionsService.php
+++ b/packages/plugin/src/Services/SubmissionsService.php
@@ -524,6 +524,7 @@ class SubmissionsService extends BaseService implements SubmissionHandlerInterfa
         foreach ($query->batch() as $results) {
             /** @var Submission $submission */
             foreach ($results as $submission) {
+                $submission = $this->getSubmission($submission->getId());
                 $uploadFields = $submission->getForm()->getLayout()->getFields(FileUploadInterface::class);
                 foreach ($uploadFields as $uploadField) {
                     $value = $submission->{$uploadField->getHandle()}->getValue();


### PR DESCRIPTION
- Added `skipContent(true)` flag back in as it was causing weird/random/missing submissions in the result set.
- I originally removed `skipContent(true)` flag as it was causing all submission field values to be null in the result set, meaning the asset ids array was always empty. Hence why assets were never deleted during purge of submissions.
- We now grab fresh submission instance that now contains all field values, allowing use to grab asset ids and correctly delete assets during purging.