### PR TITLE
[SFT-456] - When reCAPTCHA is enabled, the Drag and Drop File Upload …

### DIFF
--- a/packages/plugin/src/Bundles/Captchas/HCaptcha.php
+++ b/packages/plugin/src/Bundles/Captchas/HCaptcha.php
@@ -51,7 +51,7 @@ class HCaptcha extends FeatureBundle
             $field = $event->getField();
             $response = $this->getCheckboxResponse($event);
 
-            if (($field instanceof RecaptchaField) && !$this->validateResponse($response)) {
+            if (($field instanceof RecaptchaField) && !$response || !$this->validateResponse($response)) {
                 $message = $this->getSettings()->recaptchaErrorMessage;
                 $field->addError(Freeform::t($message ?: 'Please verify that you are not a robot.'));
             }
@@ -63,7 +63,7 @@ class HCaptcha extends FeatureBundle
         if (ReCaptchaHelper::canApplyReCaptcha($event->getForm()) && !$this->isHcaptchaTypeSkipped(Settings::RECAPTCHA_TYPE_H_INVISIBLE)) {
             $response = $this->getInvisibleResponse($event);
 
-            if (!$this->validateResponse($response)) {
+            if (!$response || !$this->validateResponse($response)) {
                 if ($this->behaviourDisplayError()) {
                     $message = $this->getSettings()->recaptchaErrorMessage;
                     $event->getForm()->addError(Freeform::t($message ?: 'Please verify that you are not a robot.'));

--- a/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
+++ b/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
@@ -61,7 +61,7 @@ class ReCaptcha extends FeatureBundle
             $field = $event->getField();
             $response = $this->getCheckboxResponse($event);
 
-            if (($field instanceof RecaptchaField) && !$this->validateResponse($response)) {
+            if (($field instanceof RecaptchaField) && !$response || !$this->validateResponse($response)) {
                 $message = $this->getSettings()->recaptchaErrorMessage;
                 $field->addError(Freeform::t($message ?: 'Please verify that you are not a robot.'));
             }
@@ -73,7 +73,7 @@ class ReCaptcha extends FeatureBundle
         if (ReCaptchaHelper::canApplyReCaptcha($event->getForm()) && !$this->isRecaptchaTypeSkipped(Settings::RECAPTCHA_TYPE_V2_INVISIBLE)) {
             $response = $this->getInvisibleResponse($event);
 
-            if (!$this->validateResponse($response)) {
+            if (!$response || !$this->validateResponse($response)) {
                 if ($this->behaviourDisplayError()) {
                     $message = $this->getSettings()->recaptchaErrorMessage;
                     $event->getForm()->addError(Freeform::t($message ?: 'Please verify that you are not a robot.'));
@@ -89,7 +89,7 @@ class ReCaptcha extends FeatureBundle
         if (ReCaptchaHelper::canApplyReCaptcha($event->getForm()) && !$this->isRecaptchaTypeSkipped(Settings::RECAPTCHA_TYPE_V3)) {
             $response = $this->getInvisibleResponse($event);
 
-            if (!$this->validateResponse($response)) {
+            if (!$response || !$this->validateResponse($response)) {
                 if ($this->behaviourDisplayError()) {
                     $message = $this->getSettings()->recaptchaErrorMessage;
                     $event->getForm()->addError(Freeform::t($message ?: 'Your submission could not be processed.'));


### PR DESCRIPTION
…field no longer shows existing file(s) previews when page is reloaded (due to going through pages, etc)

Forms with recaptcha enabled, have multiple pages with a File DnD field would send `g-recaptcha-response` with a blank value when grabbing existing files when switching between pages. The latest changes to recaptcha couldn't handle the blank value.