### PR TITLE
[v5] [SFT-576] - Not all Stripe validation errors are accounted for and cause the form to break

### DIFF
--- a/packages/plugin/src/Services/Pro/Payments/StripeService.php
+++ b/packages/plugin/src/Services/Pro/Payments/StripeService.php
@@ -78,15 +78,12 @@ class StripeService extends Component
             $customerData = CustomerDetails::fromArray($dynamicValues)->toStripeConstructArray();
             $customerData['payment_method'] = $token;
 
-            $customer = Customer::create($customerData);
-
             $paymentIntentProperties = [
                 'payment_method' => $token,
                 'amount' => $amount,
                 'currency' => $currency,
                 'confirmation_method' => 'manual',
                 'confirm' => true,
-                'customer' => $customer->id,
             ];
 
             $mapping = $properties->getCustomerFieldMapping();
@@ -98,6 +95,10 @@ class StripeService extends Component
 
             try {
                 $paymentIntent = PaymentIntent::create($paymentIntentProperties);
+
+                $customer = Customer::create($customerData);
+
+                PaymentIntent::update($paymentIntent->id, ['customer' => $customer->id]);
             } catch (\Stripe\Exception\CardException $e) {
                 $form->addError(Freeform::t($e->getMessage()));
 


### PR DESCRIPTION
Creating a customer using a declined card before making the payment intent was causing internal server error.