### PR TITLE
[SFT-538] - Phone fields don't do JS validation on front end

### DIFF
--- a/packages/plugin/src/Bundles/Fields/Validation/PhoneValidation.php
+++ b/packages/plugin/src/Bundles/Fields/Validation/PhoneValidation.php
@@ -28,6 +28,10 @@ class PhoneValidation extends FeatureBundle
         }
 
         $value = $field->getValue();
+        if (!$value) {
+            return;
+        }
+
         $pattern = $field->getPattern();
         $message = 'Invalid phone number';
 

--- a/packages/plugin/src/Fields/Implementations/Pro/PhoneField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/PhoneField.php
@@ -54,13 +54,19 @@ class PhoneField extends TextField implements PhoneMaskInterface, ExtraFieldInte
         $pattern = $this->getPattern();
         $pattern = str_replace('x', '0', $pattern);
 
-        $this->attributes
+        $attributes = $this->attributes->getInput()
+            ->clone()
             ->append('class', 'form-phone-pattern-field')
+            ->setIfEmpty('name', $this->getHandle())
+            ->setIfEmpty('type', $this->customInputType ?? 'text')
+            ->setIfEmpty('id', $this->getIdAttribute())
+            ->setIfEmpty('placeholder', $this->translate($this->getPlaceholder()))
+            ->setIfEmpty('value', $this->getValue())
             ->setIfEmpty('data-masked-input', $pattern)
             ->setIfEmpty('data-pattern', $pattern)
         ;
 
-        return parent::getInputHtml();
+        return '<input'.$attributes.' />';
     }
 
     public function getContentGqlMutationArgumentType(): array|GQLType


### PR DESCRIPTION
- Updated logic to skip validation if no value was submitted and not required
- Applied correct attributes to input so phone JS validation worked