### PR TITLE
[SFT-612]: When using `"successBehavior":"reload"` AND no AJAX, it doesn't seem to do that and uses the `return URL` instead

### DIFF
--- a/packages/plugin/src/Bundles/Form/SuccessBehavior/SuccessBehaviorBundle.php
+++ b/packages/plugin/src/Bundles/Form/SuccessBehavior/SuccessBehaviorBundle.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Solspace\Freeform\Bundles\Form\SuccessBehavior;
+
+use Solspace\Freeform\Events\Forms\SubmitResponseEvent;
+use Solspace\Freeform\Form\Form;
+use Solspace\Freeform\Form\Settings\Implementations\BehaviorSettings;
+use Solspace\Freeform\Library\Bundles\FeatureBundle;
+use yii\base\Event;
+
+class SuccessBehaviorBundle extends FeatureBundle
+{
+    public function __construct()
+    {
+        Event::on(
+            Form::class,
+            Form::EVENT_ON_SUBMIT_RESPONSE,
+            [$this, 'handleSuccessBehavior']
+        );
+    }
+
+    public function handleSuccessBehavior(SubmitResponseEvent $event): void
+    {
+        $form = $event->getForm();
+        $request = \Craft::$app->request;
+
+        $behaviorSettings = $form->getSettings()->getBehavior();
+
+        switch ($behaviorSettings->successBehavior) {
+            case BehaviorSettings::SUCCESS_BEHAVIOUR_REDIRECT_RETURN_URL:
+                $returnUrl = $this->plugin()->forms->getReturnUrl($form);
+
+                $event->getResponse()->redirect($returnUrl);
+
+                break;
+
+            case BehaviorSettings::SUCCESS_BEHAVIOUR_LOAD_SUCCESS_TEMPLATE:
+            case BehaviorSettings::SUCCESS_BEHAVIOUR_RELOAD:
+            default:
+                $url = $request->getUrl();
+                $event->getResponse()->redirect($url);
+
+                break;
+        }
+    }
+}

--- a/packages/plugin/src/Events/Forms/SubmitResponseEvent.php
+++ b/packages/plugin/src/Events/Forms/SubmitResponseEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Solspace\Freeform\Events\Forms;
+
+use Solspace\Freeform\Events\ArrayableEvent;
+use Solspace\Freeform\Events\FormEventInterface;
+use Solspace\Freeform\Form\Form;
+use yii\web\Response;
+
+class SubmitResponseEvent extends ArrayableEvent implements FormEventInterface
+{
+    public function __construct(
+        private Form $form,
+        private Response $response
+    ) {
+        parent::__construct();
+    }
+
+    public function fields(): array
+    {
+        return ['form', 'response'];
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function setResponse(Response $response): self
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+}

--- a/packages/plugin/src/Form/Form.php
+++ b/packages/plugin/src/Form/Form.php
@@ -74,6 +74,7 @@ abstract class Form implements FormTypeInterface, \IteratorAggregate, CustomNorm
     public const EVENT_OUTPUT_AS_JSON = 'output-as-json';
     public const EVENT_SET_PROPERTIES = 'set-properties';
     public const EVENT_SUBMIT = 'submit';
+    public const EVENT_ON_SUBMIT_RESPONSE = 'on-submit-response';
     public const EVENT_AFTER_SUBMIT = 'after-submit';
     public const EVENT_BEFORE_VALIDATE = 'before-validate';
     public const EVENT_AFTER_VALIDATE = 'after-validate';


### PR DESCRIPTION
* improving success behavior handling