### PR TITLE
[SFT-630] - Updated Pipedrive Leads to use Notes endpoint

### DIFF
--- a/packages/plugin/src/Integrations/CRM/PipedriveLeads.php
+++ b/packages/plugin/src/Integrations/CRM/PipedriveLeads.php
@@ -56,6 +56,9 @@ class PipedriveLeads extends AbstractPipedriveIntegration
             unset($leadFields['currency']);
             $leadFields['value'] = $value->amount ? $value : null;
 
+            $note = $leadFields['note'];
+            unset($leadFields['note']);
+
             $response = $client->post(
                 $this->getEndpoint('/leads'),
                 ['json' => $leadFields]
@@ -66,6 +69,7 @@ class PipedriveLeads extends AbstractPipedriveIntegration
 
             $this->getHandler()->onAfterResponse($this, $response);
 
+            $this->addNote('lead', $leadId, $note ?? null);
             $this->addNote('org', $orgId, $keyValueList['note___org'] ?? null);
             $this->addNote('person', $personId, $keyValueList['note___prsn'] ?? null);
         } catch (RequestException $e) {

--- a/packages/plugin/src/Integrations/CRM/PipedriveLeads.php
+++ b/packages/plugin/src/Integrations/CRM/PipedriveLeads.php
@@ -46,7 +46,7 @@ class PipedriveLeads extends AbstractPipedriveIntegration
             }
 
             if ($this->getUserId()) {
-                $fields['owner_id'] = $this->getUserId();
+                $leadFields['owner_id'] = $this->getUserId();
             }
 
             $value = new \stdClass();


### PR DESCRIPTION
- Hooked up owner_id when saving a new lead
- Removed note field when saving new lead since its deprecated
- Call notes endpoint to save lead note
 
https://solspace.atlassian.net/browse/SFT-630