### PR TITLE
[SFT-179]: Refactor the way `value` / `valueAsString` is handled so there are more intuitive options to get option label vs option value

### DIFF
--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -22,6 +22,7 @@ use Solspace\Freeform\Attributes\Property\Middleware;
 use Solspace\Freeform\Attributes\Property\Section;
 use Solspace\Freeform\Attributes\Property\Validators;
 use Solspace\Freeform\Attributes\Property\ValueTransformer;
+use Solspace\Freeform\Bundles\Fields\ImplementationProvider;
 use Solspace\Freeform\Events\Fields\ValidateEvent;
 use Solspace\Freeform\Fields\Interfaces\InputOnlyInterface;
 use Solspace\Freeform\Fields\Interfaces\NoRenderInterface;
@@ -375,7 +376,7 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
     /**
      * Gets whatever value is set and returns its string representation.
      */
-    public function getValueAsString(bool $optionsAsValues = true): string
+    public function getValueAsString(): string
     {
         $value = $this->getValue();
 
@@ -488,6 +489,24 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
         if (!$event->isValid) {
             $this->errors = [];
         }
+    }
+
+    public function implements(string ...$interfaces): bool
+    {
+        static $provider;
+        if (null === $provider) {
+            $provider = new ImplementationProvider();
+        }
+
+        $implementations = $provider->getImplementations($this::class);
+
+        foreach ($interfaces as $interface) {
+            if (\in_array($interface, $implementations, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/plugin/src/Fields/BaseGeneratedOptionsField.php
+++ b/packages/plugin/src/Fields/BaseGeneratedOptionsField.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Solspace\Freeform\Fields;
+
+use Solspace\Freeform\Attributes\Property\Implementations\Options\Option;
+use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
+use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionsTransformer;
+use Solspace\Freeform\Attributes\Property\Input;
+use Solspace\Freeform\Attributes\Property\ValueTransformer;
+use Solspace\Freeform\Fields\Interfaces\GeneratedOptionsInterface;
+use Solspace\Freeform\Fields\Properties\Options\OptionsConfigurationInterface;
+
+/**
+ * @implements \IteratorAggregate<int, Option|OptionCollection>
+ */
+abstract class BaseGeneratedOptionsField extends BaseOptionsField implements GeneratedOptionsInterface
+{
+    #[ValueTransformer(OptionsTransformer::class)]
+    #[Input\Options(
+        label: 'Options Editor',
+        instructions: 'Define your options',
+    )]
+    protected ?OptionsConfigurationInterface $optionConfiguration = null;
+
+    public function getOptionConfiguration(): ?OptionsConfigurationInterface
+    {
+        return $this->optionConfiguration;
+    }
+
+    public function getOptions(): OptionCollection
+    {
+        return $this->optionConfiguration->getOptions();
+    }
+}

--- a/packages/plugin/src/Fields/BaseOptionsField.php
+++ b/packages/plugin/src/Fields/BaseOptionsField.php
@@ -4,31 +4,41 @@ namespace Solspace\Freeform\Fields;
 
 use Solspace\Freeform\Attributes\Property\Implementations\Options\Option;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
-use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionsTransformer;
-use Solspace\Freeform\Attributes\Property\Input;
-use Solspace\Freeform\Attributes\Property\ValueTransformer;
-use Solspace\Freeform\Fields\Interfaces\GeneratedOptionsInterface;
-use Solspace\Freeform\Fields\Properties\Options\OptionsConfigurationInterface;
+use Solspace\Freeform\Fields\Interfaces\MultiValueInterface;
+use Solspace\Freeform\Fields\Interfaces\OptionsInterface;
 
 /**
  * @implements \IteratorAggregate<int, Option|OptionCollection>
  */
-abstract class BaseOptionsField extends AbstractField implements GeneratedOptionsInterface
+abstract class BaseOptionsField extends AbstractField implements OptionsInterface
 {
-    #[ValueTransformer(OptionsTransformer::class)]
-    #[Input\Options(
-        label: 'Options Editor',
-        instructions: 'Define your options',
-    )]
-    protected ?OptionsConfigurationInterface $optionConfiguration = null;
-
-    public function getOptionConfiguration(): ?OptionsConfigurationInterface
+    public function getLabels(): array
     {
-        return $this->optionConfiguration;
+        $labels = [];
+
+        foreach ($this->getOptions() as $option) {
+            if (!$option instanceof Option) {
+                continue;
+            }
+
+            if ($this instanceof MultiValueInterface) {
+                if (!\in_array($option->getValue(), $this->getValue())) {
+                    continue;
+                }
+            } else {
+                if ($option->getValue() != $this->getValue()) {
+                    continue;
+                }
+            }
+
+            $labels[] = $option->getLabel();
+        }
+
+        return $labels;
     }
 
-    public function getOptions(): OptionCollection
+    public function getLabelsAsString(): string
     {
-        return $this->optionConfiguration->getOptions();
+        return implode(', ', $this->getLabels());
     }
 }

--- a/packages/plugin/src/Fields/FieldInterface.php
+++ b/packages/plugin/src/Fields/FieldInterface.php
@@ -120,4 +120,6 @@ interface FieldInterface
     public function setParameters(array $parameters = null): void;
 
     public function getAttributes(): FieldAttributesCollection;
+
+    public function implements(string ...$interfaces): bool;
 }

--- a/packages/plugin/src/Fields/Implementations/CheckboxesField.php
+++ b/packages/plugin/src/Fields/Implementations/CheckboxesField.php
@@ -16,7 +16,7 @@ use GraphQL\Type\Definition\Type as GQLType;
 use Solspace\Freeform\Attributes\Field\Type;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
 use Solspace\Freeform\Attributes\Property\Input\Hidden;
-use Solspace\Freeform\Fields\BaseOptionsField;
+use Solspace\Freeform\Fields\BaseGeneratedOptionsField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\MultiValueInterface;
 use Solspace\Freeform\Fields\Interfaces\OneLineInterface;
@@ -29,7 +29,7 @@ use Solspace\Freeform\Fields\Traits\OneLineTrait;
     iconPath: __DIR__.'/Icons/checkboxes.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/checkboxes.ejs',
 )]
-class CheckboxesField extends BaseOptionsField implements MultiValueInterface, OneLineInterface, DefaultValueInterface
+class CheckboxesField extends BaseGeneratedOptionsField implements MultiValueInterface, OneLineInterface, DefaultValueInterface
 {
     use MultipleValueTrait;
     use OneLineTrait;
@@ -86,23 +86,6 @@ class CheckboxesField extends BaseOptionsField implements MultiValueInterface, O
         }
 
         return $output;
-    }
-
-    public function getValueAsString(bool $optionsAsValues = true): string
-    {
-        if (!$optionsAsValues) {
-            return implode(', ', $this->getValue());
-        }
-
-        $labels = [];
-        foreach ($this->getOptions() as $option) {
-            $isChecked = \in_array($option->getValue(), $this->getValue());
-            if ($isChecked) {
-                $labels[] = $option->getLabel();
-            }
-        }
-
-        return implode(', ', $labels);
     }
 
     public function getContentGqlType(): array|GQLType

--- a/packages/plugin/src/Fields/Implementations/DropdownField.php
+++ b/packages/plugin/src/Fields/Implementations/DropdownField.php
@@ -14,9 +14,8 @@ namespace Solspace\Freeform\Fields\Implementations;
 
 use GraphQL\Type\Definition\Type as GQLType;
 use Solspace\Freeform\Attributes\Field\Type;
-use Solspace\Freeform\Attributes\Property\Implementations\Options\Option;
 use Solspace\Freeform\Attributes\Property\Input\Hidden;
-use Solspace\Freeform\Fields\BaseOptionsField;
+use Solspace\Freeform\Fields\BaseGeneratedOptionsField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 
 #[Type(
@@ -25,7 +24,7 @@ use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
     iconPath: __DIR__.'/Icons/dropdown.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/dropdown.ejs',
 )]
-class DropdownField extends BaseOptionsField implements DefaultValueInterface
+class DropdownField extends BaseGeneratedOptionsField implements DefaultValueInterface
 {
     #[Hidden]
     protected string $defaultValue = '';
@@ -61,21 +60,6 @@ class DropdownField extends BaseOptionsField implements DefaultValueInterface
         $output .= '</select>';
 
         return $output;
-    }
-
-    public function getValueAsString(bool $optionsAsValues = true): string
-    {
-        if (!$optionsAsValues) {
-            return $this->getValue();
-        }
-
-        foreach ($this->getOptions() as $option) {
-            if ($option instanceof Option && $option->getValue() === $this->getValue()) {
-                return $option->getLabel();
-            }
-        }
-
-        return '';
     }
 
     public function getContentGqlMutationArgumentType(): array|GQLType

--- a/packages/plugin/src/Fields/Implementations/MultipleSelectField.php
+++ b/packages/plugin/src/Fields/Implementations/MultipleSelectField.php
@@ -15,9 +15,8 @@ namespace Solspace\Freeform\Fields\Implementations;
 
 use GraphQL\Type\Definition\Type as GQLType;
 use Solspace\Freeform\Attributes\Field\Type;
-use Solspace\Freeform\Attributes\Property\Implementations\Options\Option;
 use Solspace\Freeform\Attributes\Property\Input\Hidden;
-use Solspace\Freeform\Fields\BaseOptionsField;
+use Solspace\Freeform\Fields\BaseGeneratedOptionsField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\MultiValueInterface;
 use Solspace\Freeform\Fields\Traits\MultipleValueTrait;
@@ -28,7 +27,7 @@ use Solspace\Freeform\Fields\Traits\MultipleValueTrait;
     iconPath: __DIR__.'/Icons/multi-select.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/multiple-select.ejs',
 )]
-class MultipleSelectField extends BaseOptionsField implements MultiValueInterface, DefaultValueInterface
+class MultipleSelectField extends BaseGeneratedOptionsField implements MultiValueInterface, DefaultValueInterface
 {
     use MultipleValueTrait;
 
@@ -69,22 +68,6 @@ class MultipleSelectField extends BaseOptionsField implements MultiValueInterfac
         $output .= '</select>';
 
         return $output;
-    }
-
-    public function getValueAsString(bool $optionsAsValues = true): string
-    {
-        if (!$optionsAsValues) {
-            return implode(', ', $this->getValue());
-        }
-
-        $labels = [];
-        foreach ($this->getOptions() as $option) {
-            if ($option instanceof Option && \in_array($option->getValue(), $this->getValue(), true)) {
-                $labels[] = $option->getLabel();
-            }
-        }
-
-        return implode(', ', $labels);
     }
 
     public function getContentGqlType(): array|GQLType

--- a/packages/plugin/src/Fields/Implementations/Pro/OpinionScaleField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/OpinionScaleField.php
@@ -9,7 +9,7 @@ use Solspace\Freeform\Attributes\Property\Implementations\OpinionScale\ScalesTra
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
 use Solspace\Freeform\Attributes\Property\Input;
 use Solspace\Freeform\Attributes\Property\ValueTransformer;
-use Solspace\Freeform\Fields\AbstractField;
+use Solspace\Freeform\Fields\BaseOptionsField;
 use Solspace\Freeform\Fields\Interfaces\ExtraFieldInterface;
 use Solspace\Freeform\Fields\Interfaces\OptionsInterface;
 use Solspace\Freeform\Fields\Properties\OpinionScale\Legend;
@@ -21,7 +21,7 @@ use Solspace\Freeform\Fields\Properties\OpinionScale\Scale;
     iconPath: __DIR__.'/../Icons/opinion-scale.svg',
     previewTemplatePath: __DIR__.'/../PreviewTemplates/opinion-scale.ejs',
 )]
-class OpinionScaleField extends AbstractField implements ExtraFieldInterface, OptionsInterface
+class OpinionScaleField extends BaseOptionsField implements ExtraFieldInterface, OptionsInterface
 {
     #[ValueTransformer(ScalesTransformer::class)]
     #[Input\TabularData(

--- a/packages/plugin/src/Fields/Implementations/Pro/Payments/CreditCardDetailsField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/Payments/CreditCardDetailsField.php
@@ -116,7 +116,7 @@ class CreditCardDetailsField extends AbstractField implements PaymentInterface, 
         return SubmissionHookHandler::renderColumn(SubmissionHookHandler::COLUMN_STATUS);
     }
 
-    public function getValueAsString(bool $optionsAsValues = true): string
+    public function getValueAsString(): string
     {
         return '';
     }

--- a/packages/plugin/src/Fields/Implementations/Pro/RatingField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/RatingField.php
@@ -6,7 +6,7 @@ use GraphQL\Type\Definition\Type as GQLType;
 use Solspace\Freeform\Attributes\Field\Type;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
 use Solspace\Freeform\Attributes\Property\Input;
-use Solspace\Freeform\Fields\AbstractField;
+use Solspace\Freeform\Fields\BaseOptionsField;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\ExtraFieldInterface;
 use Solspace\Freeform\Fields\Interfaces\OptionsInterface;
@@ -19,7 +19,7 @@ use Solspace\Freeform\Library\Helpers\HashHelper;
     iconPath: __DIR__.'/../Icons/rating.svg',
     previewTemplatePath: __DIR__.'/../PreviewTemplates/rating.ejs',
 )]
-class RatingField extends AbstractField implements ExtraFieldInterface, OptionsInterface
+class RatingField extends BaseOptionsField implements ExtraFieldInterface, OptionsInterface
 {
     public const MIN_VALUE = 3;
     public const MAX_VALUE = 10;

--- a/packages/plugin/src/Fields/Implementations/RadiosField.php
+++ b/packages/plugin/src/Fields/Implementations/RadiosField.php
@@ -16,7 +16,7 @@ use GraphQL\Type\Definition\Type as GQLType;
 use Solspace\Freeform\Attributes\Field\Type;
 use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollection;
 use Solspace\Freeform\Attributes\Property\Input\Hidden;
-use Solspace\Freeform\Fields\BaseOptionsField;
+use Solspace\Freeform\Fields\BaseGeneratedOptionsField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\OneLineInterface;
 use Solspace\Freeform\Fields\Traits\OneLineTrait;
@@ -27,7 +27,7 @@ use Solspace\Freeform\Fields\Traits\OneLineTrait;
     iconPath: __DIR__.'/Icons/radios.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/radios.ejs',
 )]
-class RadiosField extends BaseOptionsField implements OneLineInterface, DefaultValueInterface
+class RadiosField extends BaseGeneratedOptionsField implements OneLineInterface, DefaultValueInterface
 {
     use OneLineTrait;
 
@@ -79,21 +79,6 @@ class RadiosField extends BaseOptionsField implements OneLineInterface, DefaultV
         }
 
         return $output;
-    }
-
-    public function getValueAsString(bool $optionsAsValues = true): string
-    {
-        if (!$optionsAsValues) {
-            return $this->getValue();
-        }
-
-        foreach ($this->getOptions() as $option) {
-            if ($option instanceof Option && $option->getValue() === $this->getValue()) {
-                return $option->getLabel();
-            }
-        }
-
-        return '';
     }
 
     public function getContentGqlMutationArgumentType(): array|GQLType

--- a/packages/plugin/src/Fields/Interfaces/OptionsInterface.php
+++ b/packages/plugin/src/Fields/Interfaces/OptionsInterface.php
@@ -17,4 +17,8 @@ use Solspace\Freeform\Attributes\Property\Implementations\Options\OptionCollecti
 interface OptionsInterface
 {
     public function getOptions(): OptionCollection;
+
+    public function getLabels(): array;
+
+    public function getLabelsAsString(): string;
 }

--- a/packages/plugin/src/Services/Pro/Payments/StripeService.php
+++ b/packages/plugin/src/Services/Pro/Payments/StripeService.php
@@ -89,7 +89,7 @@ class StripeService extends Component
             $mapping = $properties->getCustomerFieldMapping();
             if (isset($mapping['email']) && $form->get($mapping['email'])) {
                 if ($integration->isSendOnSuccess()) {
-                    $paymentIntentProperties['receipt_email'] = $form->get($mapping['email'])->getValueAsString();
+                    $paymentIntentProperties['receipt_email'] = $form->get($mapping['email'])->getValue();
                 }
             }
 

--- a/packages/plugin/src/Tests/Fields/FieldInterfaceTest.php
+++ b/packages/plugin/src/Tests/Fields/FieldInterfaceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Solspace\Freeform\Tests\Fields;
+
+use PHPUnit\Framework\TestCase;
+use Solspace\Freeform\Fields\Implementations\DropdownField;
+use Solspace\Freeform\Form\Form;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class FieldInterfaceTest extends TestCase
+{
+    public function testImplementations()
+    {
+        $formMock = $this->createMock(Form::class);
+        $field = new DropdownField($formMock);
+
+        $this->assertTrue($field->implements('options'));
+        $this->assertTrue($field->implements('generatedOptions'));
+        $this->assertTrue($field->implements('nothing', 'nothing else', 'defaultValue'));
+        $this->assertFalse($field->implements('foobar'));
+        $this->assertFalse($field->implements('foobar', 'baz'));
+    }
+}

--- a/packages/plugin/src/Twig/Filters/FreeformTwigFilters.php
+++ b/packages/plugin/src/Twig/Filters/FreeformTwigFilters.php
@@ -17,7 +17,7 @@ class FreeformTwigFilters extends AbstractExtension
     public function truncateFilter($input, $length = 50, $ellipsis = '...'): string
     {
         if (\strlen($input) <= $length) {
-            return $input;
+            return $input ?? '';
         }
 
         return substr($input, 0, $length - \strlen($ellipsis)).'...';

--- a/packages/plugin/src/codepack/templates/extras/manual-form.twig
+++ b/packages/plugin/src/codepack/templates/extras/manual-form.twig
@@ -66,9 +66,8 @@
             </div>
 
             <div class="form-field">
-                {# Completely manual - for the value, it uses 'valueAsString' as opposed to 'value' since Email fields are currently stored as an array #}
                 <label>Email Address</label>
-                <input name="email" value="{{ email.valueAsString }}" />
+                <input name="email" value="{{ email.value }}" />
                 {{ form.get("email").renderErrors() }}
             </div>
 

--- a/packages/plugin/src/codepack/templates/extras/manual-multipage.twig
+++ b/packages/plugin/src/codepack/templates/extras/manual-multipage.twig
@@ -84,9 +84,8 @@
             {% elseif form.currentPage.index == 1 %}
 
                 <div class="form-field">
-                    {# Completely manual - for the value, it uses 'valueAsString' as opposed to 'value' since Email fields are currently stored as an array #}
                     <label>Email Address</label>
-                    <input name="email" value="{{ email.valueAsString }}" />
+                    <input name="email" value="{{ email.value }}" />
                     {{ form.get("email").renderErrors() }}
                 </div>
 

--- a/packages/plugin/src/codepack/templates/submissions/index.twig
+++ b/packages/plugin/src/codepack/templates/submissions/index.twig
@@ -76,7 +76,13 @@
                             {% endif %}
                             </td>
                         {% else %}
-                            <td>{{ submission[field.handle]|truncate(40, '...') }}</td>
+                            <td>
+                            {% if field.implements('options') %}
+                                {{ submission[field.handle].labelsAsString|truncate(40, '...') }}
+                            {% else %}
+                                {{ submission[field.handle].valueAsString|truncate(40, '...') }}
+                            {% endif %}
+                            </td>
                         {% endif %}
                     {% endfor %}
                     {% if freeform.pro %}

--- a/packages/plugin/src/codepack/templates/submissions/view.twig
+++ b/packages/plugin/src/codepack/templates/submissions/view.twig
@@ -74,7 +74,7 @@
                         </tr>
                         {% for field in submission %}
                             <tr>
-                                <th style="width: 20%;">{{ field.label }}</th>
+                                <th style="width: 20%;">{{ field.label|raw }}</th>
                                 <td>
                                     {% if field.type == "file" %}
 
@@ -117,7 +117,11 @@
                                             <img src="{{ submission[field.handle] }}" alt="">
                                         {% endif %}
                                     {% else %}
-                                        {{ submission[field.handle] }}
+                                        {% if field.implements('options') %}
+                                            {{ submission[field.handle].labelsAsString }}
+                                        {% else %}
+                                            {{ submission[field.handle].valueAsString }}
+                                        {% endif %}
                                     {% endif %}
                                 </td>
                             </tr>

--- a/packages/plugin/src/templates/_templates/formatting/basic-light/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/basic-light/_main.css
@@ -216,7 +216,7 @@ button[type=submit].freeform-processing:before {
 .freeform-row [class*="freeform-col-"] input::placeholder,
 .freeform-row [class*="freeform-col-"] textarea::placeholder {
     font: normal 16px sans-serif;
-    color: #6c757d;
+    color: #959ea5;
 }
 .freeform-row [class*="freeform-col-"] input.freeform-has-errors,
 .freeform-row [class*="freeform-col-"] .freeform-input.StripeElement--invalid,

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/_main.css
@@ -29,6 +29,9 @@ label.required:after {
     color: #d00;
     margin-left: 3px;
 }
+input::placeholder {
+    color: #454749 !important;
+}
 .alert p:last-of-type {
     margin-bottom: 0;
 }

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5/_main.css
@@ -29,6 +29,9 @@ label.required:after {
     color: #d00;
     margin-left: 3px;
 }
+input::placeholder {
+    color: #a2a6aa !important;
+}
 .alert p:last-of-type {
     margin-bottom: 0;
 }

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5/index.twig
@@ -24,7 +24,7 @@
                 container: { class: "mb-3 col-12" },
                 input: {
                     novalidate: true,
-                    class: "form-control"
+                    class: "form-control placeholder-red",
                 },
                 label: { class: "mb-1" },
                 instructions: { class: "form-text text-muted mt-n1 mb-1" },

--- a/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/_main.css
@@ -243,7 +243,7 @@ button[type=submit].freeform-processing:before {
 .freeform-row [class*="freeform-col-"] input::placeholder,
 .freeform-row [class*="freeform-col-"] textarea::placeholder {
     font: normal 16px sans-serif;
-    color: #6c757d;
+    color: #959ea5;
 }
 .freeform-row [class*="freeform-col-"] input.freeform-has-errors,
 .freeform-row [class*="freeform-col-"] .freeform-input.StripeElement--invalid,


### PR DESCRIPTION
* adding `::labels()` and `::labelsAsString()` methods to all option fields.
* adding `::implements()` method to all fields for twig friendly implementation checks
* refactoring `::valueAsString` to not take a parameter