### PR TITLE
[SFT-695]: 🔥 When saving an integration (non-singleton) in the Settings area it now triggers an `Undefined array key "class"` error

### DIFF
--- a/packages/plugin/src/controllers/integrations/IntegrationsController.php
+++ b/packages/plugin/src/controllers/integrations/IntegrationsController.php
@@ -88,7 +88,9 @@ abstract class IntegrationsController extends BaseController
         $id = $post['id'] ?? null;
         $model = $this->getNewOrExistingModel($id);
 
-        $model->class = $post['class'];
+        if (!$model->id) {
+            $model->class = $post['class'];
+        }
 
         $properties = $post['properties'][$model->class] ?? [];
         $post['metadata'] = $properties ?: null;


### PR DESCRIPTION
* fixing integrations