### PR TITLE
[SFT-725] - Removed Custom Header requirement for GraphQL submission mutation

### DIFF
--- a/packages/plugin/src/Bundles/Form/Context/Request/GraphQLContext.php
+++ b/packages/plugin/src/Bundles/Form/Context/Request/GraphQLContext.php
@@ -22,34 +22,36 @@ class GraphQLContext
         $request = $event->getRequest();
         $arguments = $event->getArguments();
 
+        if (!$form->isFormPosted() || !$form->isPagePosted()) {
+            return;
+        }
+
         if ($request->isConsoleRequest) {
             return;
         }
 
-        if ($request->getHeaders()->get('x-craft-gql-schema') || $request->getHeaders()->get('X-Craft-Solspace-Freeform-Mode')) {
-            foreach ($form->getLayout()->getFields() as $field) {
-                if ($field instanceof PersistentValueInterface || !$field->getHandle()) {
-                    continue;
+        foreach ($form->getLayout()->getFields() as $field) {
+            if ($field instanceof PersistentValueInterface || !$field->getHandle()) {
+                continue;
+            }
+
+            if (!$field->includeInGqlSchema()) {
+                continue;
+            }
+
+            if (isset($arguments[$field->getHandle()])) {
+                $postedValue = $arguments[$field->getHandle()];
+
+                $event = new TransformValueEvent($field, $postedValue);
+                Event::trigger(FieldInterface::class, FieldInterface::EVENT_TRANSFORM_FROM_POST, $event);
+
+                if (!$event->isValid) {
+                    return;
                 }
 
-                if (!$field->includeInGqlSchema()) {
-                    continue;
-                }
-
-                if (isset($arguments[$field->getHandle()])) {
-                    $postedValue = $arguments[$field->getHandle()];
-
-                    $event = new TransformValueEvent($field, $postedValue);
-                    Event::trigger(FieldInterface::class, FieldInterface::EVENT_TRANSFORM_FROM_POST, $event);
-
-                    if (!$event->isValid) {
-                        return;
-                    }
-
-                    $field->setValue($event->getValue());
-                } else {
-                    $field->setValue(null);
-                }
+                $field->setValue($event->getValue());
+            } else {
+                $field->setValue(null);
             }
         }
     }


### PR DESCRIPTION
Headless approaches using React/Next/Vue no longer have to pass a specific Freeform header in GraphQL requests for submission mutations to work.

Resolves issue https://github.com/solspace/craft-freeform/issues/888
