### PR TITLE
[SFT-746]: Success and error messages are not escaped for use in HTML attributes

### DIFF
--- a/packages/plugin/src/Library/Composer/Components/Form.php
+++ b/packages/plugin/src/Library/Composer/Components/Form.php
@@ -15,7 +15,6 @@ namespace Solspace\Freeform\Library\Composer\Components;
 
 use craft\helpers\Template;
 use Psr\Log\LoggerInterface;
-use Solspace\Commons\Helpers\StringHelper;
 use Solspace\Freeform\Bundles\Form\Context\Request\EditSubmissionContext;
 use Solspace\Freeform\Bundles\Form\PayloadForwarding\PayloadForwarding;
 use Solspace\Freeform\Events\Forms\AttachFormAttributesEvent;
@@ -56,6 +55,7 @@ use Solspace\Freeform\Library\Exceptions\FreeformException;
 use Solspace\Freeform\Library\FileUploads\FileUploadHandlerInterface;
 use Solspace\Freeform\Library\FormTypes\FormTypeInterface;
 use Solspace\Freeform\Library\Helpers\ReCaptchaHelper;
+use Solspace\Freeform\Library\Helpers\StringHelper;
 use Solspace\Freeform\Library\Logging\FreeformLogger;
 use Solspace\Freeform\Library\Rules\RuleProperties;
 use Solspace\Freeform\Library\Translations\TranslatorInterface;

--- a/packages/plugin/src/Library/Helpers/StringHelper.php
+++ b/packages/plugin/src/Library/Helpers/StringHelper.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Solspace\Freeform\Library\Helpers;
+
+class StringHelper
+{
+    /**
+     * Replaces all of "{someKey}" occurrences in $string
+     * with their respective value counterparts from $values array.
+     */
+    public static function replaceValues(string $string, array $values): string
+    {
+        foreach (self::flattenArrayValues($values) as $key => $value) {
+            $string = (string) preg_replace("/\\{{$key}\\}/", $value, $string);
+        }
+
+        return $string;
+    }
+
+    public static function flattenArrayValues(array $values): array
+    {
+        $return = [];
+
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $value = implode(', ', $value);
+            }
+
+            $return[$key] = $value;
+        }
+
+        return $return;
+    }
+
+    /**
+     * Splits an underscored of camel-cased string into separate words.
+     */
+    public static function humanize(string $string): string
+    {
+        return strtolower(trim(preg_replace(['/([A-Z])/', '/[_\\s]+/'], ['_$1', ' '], $string)));
+    }
+
+    /**
+     * Turns every first letter in every word in the string into a camel cased letter.
+     */
+    public static function camelize(string $string, string $delimiter = ' '): string
+    {
+        $stringParts = explode($delimiter, $string);
+        $camelized = array_map('ucwords', $stringParts);
+
+        return implode($delimiter, $camelized);
+    }
+
+    /**
+     * Walk through the array and create an HTML tag attribute string.
+     */
+    public static function compileAttributeStringFromArray(array $array): string
+    {
+        $attributeString = '';
+
+        foreach ($array as $key => $value) {
+            if (null === $value || (\is_bool($value) && $value)) {
+                $attributeString .= "{$key} ";
+            } elseif (!\is_bool($value)) {
+                $value = htmlspecialchars($value, \ENT_QUOTES, 'UTF-8');
+                $attributeString .= "{$key}=\"{$value}\" ";
+            }
+        }
+
+        return $attributeString ? ' '.$attributeString : '';
+    }
+
+    /**
+     * Takes any items separated by a whitespace or any of the following `|,;` in a string
+     * And returns an array of the items.
+     */
+    public static function extractSeparatedValues(string $string): array
+    {
+        $string = preg_replace('/[\s|,;]+/', '<|_|_|>', $string);
+
+        $items = explode('<|_|_|>', $string);
+        $items = array_filter($items);
+        $items = array_unique($items);
+
+        return array_values($items);
+    }
+
+    public static function implodeRecursively(string $glue, mixed $data): string
+    {
+        if (!\is_array($data)) {
+            return $data;
+        }
+
+        $pieces = [];
+        foreach ($data as $item) {
+            if (\is_array($item)) {
+                $pieces[] = self::implodeRecursively($glue, $item);
+            } else {
+                $pieces[] = $item;
+            }
+        }
+
+        return implode($glue, $pieces);
+    }
+}


### PR DESCRIPTION
* pulling out `StringHelper` from `Commons` as a built-in library in FF
* fixing attributes not being escaped properly when compiled