### PR TITLE
[SFT-745]: The `freeform_lock` isn't updating on a customer's site, causing other issues

### DIFF
--- a/packages/plugin/src/Services/SubmissionsService.php
+++ b/packages/plugin/src/Services/SubmissionsService.php
@@ -522,6 +522,8 @@ class SubmissionsService extends BaseService implements SubmissionHandlerInterfa
 
         $assetIds = [];
         foreach ($query->batch() as $results) {
+            $deletableIds = [];
+
             /** @var Submission $submission */
             foreach ($results as $submission) {
                 $submission = $this->getSubmission($submission->getId());
@@ -533,10 +535,15 @@ class SubmissionsService extends BaseService implements SubmissionHandlerInterfa
                     }
                 }
 
-                if (\Craft::$app->elements->deleteElement($submission)) {
-                    ++$deletedSubmissions;
-                }
+                $deletableIds[] = $submission->id;
             }
+
+            \Craft::$app->db
+                ->createCommand()
+                ->delete(Table::ELEMENTS, ['id' => $deletableIds])
+                ->execute();
+
+            $deletedSubmissions += \count($deletableIds);
         }
 
         $assetIds = array_unique($assetIds);


### PR DESCRIPTION
### Description

* moving away from `Element::delete()` to a direct DB SQL DELETE expression that removes elements by ID's.