### PR TITLE
[SFT-720] Updated how fields get retrieved when Exporting

### DIFF
--- a/packages/plugin/src/Controllers/Pro/QuickExportController.php
+++ b/packages/plugin/src/Controllers/Pro/QuickExportController.php
@@ -69,7 +69,7 @@ class QuickExportController extends BaseController
                     $isChecked = (bool) $item['checked'];
 
                     if (is_numeric($fieldId)) {
-                        $field = $form->getLayout()->getFieldById($fieldId);
+                        $field = $form->get($fieldId);
                         if (!$field || $field instanceof CreditCardDetailsField) {
                             continue;
                         }

--- a/packages/plugin/src/Library/Composer/Components/Fields/FieldCollection.php
+++ b/packages/plugin/src/Library/Composer/Components/Fields/FieldCollection.php
@@ -42,7 +42,7 @@ class FieldCollection implements \IteratorAggregate
         return $indexed;
     }
 
-    public function get(int|string $identificator): ?FieldInterface
+    public function get(int|string $identificator): FieldInterface
     {
         foreach ($this->fields as $field) {
             if (
@@ -53,7 +53,7 @@ class FieldCollection implements \IteratorAggregate
             }
         }
 
-        return null;
+        throw new FreeformException("Field with handle '{$identificator}' not found");
     }
 
     public function has(int|string $identificator): bool

--- a/packages/plugin/src/Library/Composer/Components/Layout.php
+++ b/packages/plugin/src/Library/Composer/Components/Layout.php
@@ -140,17 +140,17 @@ class Layout implements \JsonSerializable, \Iterator
         return $this->fieldCollection->getIndexedByHandle();
     }
 
-    public function getFieldById(int $id): ?FieldInterface
+    public function getFieldById(int $id): FieldInterface
     {
         return $this->fieldCollection->get($id);
     }
 
-    public function getFieldByHandle(string $handle): ?FieldInterface
+    public function getFieldByHandle(string $handle): FieldInterface
     {
         return $this->fieldCollection->get($handle);
     }
 
-    public function getFieldByHash(string $hash): ?FieldInterface
+    public function getFieldByHash(string $hash): FieldInterface
     {
         return $this->fieldCollection->get($hash);
     }

--- a/packages/plugin/src/Models/Pro/ExportProfileModel.php
+++ b/packages/plugin/src/Models/Pro/ExportProfileModel.php
@@ -152,7 +152,7 @@ class ExportProfileModel extends Model
                 $isChecked = (bool) $item['checked'];
 
                 if (is_numeric($fieldId)) {
-                    $field = $form->getLayout()->getFieldById($fieldId);
+                    $field = $form->get($fieldId);
                     if (!$field || $field instanceof CreditCardDetailsField) {
                         continue;
                     }
@@ -282,7 +282,7 @@ class ExportProfileModel extends Model
             }
 
             if (is_numeric($fieldId)) {
-                $field = $form->getLayout()->getFieldById($fieldId);
+                $field = $form->get($fieldId);
                 if (!$field || $field instanceof CreditCardDetailsField) {
                     continue;
                 }
@@ -334,7 +334,7 @@ class ExportProfileModel extends Model
 
                 $fieldId = $id;
                 if (is_numeric($id)) {
-                    $field = $form->getLayout()->getFieldById($id);
+                    $field = $form->get($id);
                     if (!$field || $field instanceof CreditCardDetailsField) {
                         continue;
                     }


### PR DESCRIPTION
Returning `?FieldInterface` in `getFieldById` caused an error to be thrown in some cases, such as Recent dashboard widget.