### PR TITLE
[SFT-722] - Added fallback value when field label is blank

### DIFF
--- a/packages/plugin/src/Library/Composer/Components/AbstractField.php
+++ b/packages/plugin/src/Library/Composer/Components/AbstractField.php
@@ -636,7 +636,7 @@ abstract class AbstractField implements FieldInterface, \JsonSerializable
         $forAttribute = sprintf(' for="%s"', $this->getIdAttribute());
 
         $output = '<label'.$forAttribute.$this->getLabelAttributesString().'>';
-        $output .= $this->getLabel();
+        $output .= (empty($this->label)) ? '&nbsp;' : $this->getLabel();
         $output .= '</label>';
         $output .= \PHP_EOL;
 

--- a/packages/plugin/src/Library/Composer/Components/AbstractField.php
+++ b/packages/plugin/src/Library/Composer/Components/AbstractField.php
@@ -16,6 +16,7 @@ use craft\helpers\Template;
 use GraphQL\Type\Definition\Type;
 use Solspace\Commons\Helpers\StringHelper;
 use Solspace\Freeform\Fields\CheckboxField;
+use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\Composer\Components\Attributes\CustomFieldAttributes;
 use Solspace\Freeform\Library\Composer\Components\Fields\Interfaces\InputOnlyInterface;
 use Solspace\Freeform\Library\Composer\Components\Fields\Interfaces\NoRenderInterface;
@@ -381,6 +382,15 @@ abstract class AbstractField implements FieldInterface, \JsonSerializable
 
     public function getLabel(): string
     {
+        if (empty($this->label)) {
+            $field = Freeform::getInstance()->fields->getFieldById($this->getId());
+            if ($field) {
+                return $this->translate($field->label);
+            }
+
+            return $this->getHandle();
+        }
+
         return $this->translate($this->label);
     }
 


### PR DESCRIPTION
When field label is set to blank, we attempt to use field label from the blueprint / freeform_fields table.
If no field is found, we fallback to using the field handle.