### PR TITLE
[SFT-724] - Field handle validation shouldn't FORCE camelCase without exceptions #891

### DIFF
--- a/packages/plugin/src/Library/Helpers/HandleHelper.php
+++ b/packages/plugin/src/Library/Helpers/HandleHelper.php
@@ -2,8 +2,6 @@
 
 namespace Solspace\Freeform\Library\Helpers;
 
-use craft\helpers\StringHelper;
-
 class HandleHelper
 {
     public static function generateHandle(string $input): string
@@ -11,9 +9,8 @@ class HandleHelper
         $output = $input;
 
         $output = \Transliterator::create('Any-Latin; Latin-ASCII')->transliterate($output);
-        $output = StringHelper::toCamelCase($output);
-        $output = preg_replace('/[^a-z0-9\-_]/i', '', $output);
+        $output = preg_replace('/[^A-Za-z0-9\_]/i', '', $output);
 
-        return trim($output, ' -_');
+        return trim($output, ' -');
     }
 }

--- a/packages/plugin/tests/Unit/Library/Helpers/HandleHelperTest.php
+++ b/packages/plugin/tests/Unit/Library/Helpers/HandleHelperTest.php
@@ -15,15 +15,15 @@ class HandleHelperTest extends TestCase
     public function testGeneratesFromSimpleSentence(): void
     {
         $this->assertEquals(
-            'someLabelToHandle',
-            HandleHelper::generateHandle('Some label to handle')
+            'somelabeltohandle',
+            HandleHelper::generateHandle('some label to handle')
         );
     }
 
     public function testGeneratesFromMixedCaseLetters(): void
     {
         $this->assertEquals(
-            'someMIXedLettersHereANDTHERE',
+            'SomeMIXedLettersHereANDTHERE',
             HandleHelper::generateHandle('SomeMIXedLettersHereANDTHERE')
         );
     }
@@ -31,15 +31,15 @@ class HandleHelperTest extends TestCase
     public function testGeneratesFromComplexString()
     {
         $this->assertEquals(
-            '1234THiSISaComplexCase',
-            HandleHelper::generateHandle('€$$$ 123__-4 - THiS ISaComplex case')
+            '123__4THiSISaComplexcase',
+            HandleHelper::generateHandle('€$$$ 123__-4 - THiS ISaComplex case?')
         );
     }
 
     public function testGeneratesFromCyrillic()
     {
         $this->assertEquals(
-            'privetEtoRusskij',
+            'privetetorusskij',
             HandleHelper::generateHandle('привет это русский')
         );
     }
@@ -47,8 +47,24 @@ class HandleHelperTest extends TestCase
     public function testGeneratesFromJapaneseCharacters()
     {
         $this->assertEquals(
-            'oWeniHewase',
+            'owenihewase',
             HandleHelper::generateHandle('お問い合わせ')
+        );
+    }
+
+    public function testGeneratesFromMixedCaseWithSpacesAndDashes(): void
+    {
+        $this->assertEquals(
+            'SomeLabelTOhandle',
+            HandleHelper::generateHandle('Some Label-TO-handle')
+        );
+    }
+
+    public function testGeneratesFromUnderscoresAndCapitalizationAnywhere(): void
+    {
+        $this->assertEquals(
+            'My_Field_Handle',
+            HandleHelper::generateHandle('My_Field_Handle')
         );
     }
 }


### PR DESCRIPTION
Removed camel case enforcement. 
Updated existing unit test cases, adding two new unit tests.

![image](https://github.com/solspace/craft-freeform/assets/580403/f2d2db5d-012a-48f6-856f-79dd712ae761)
