### PR TITLE
[SFT-145] - Migrations - Removed old column

### DIFF
--- a/packages/plugin/src/migrations/m230101_100000_ConvertTextToJsonColumns.php
+++ b/packages/plugin/src/migrations/m230101_100000_ConvertTextToJsonColumns.php
@@ -8,7 +8,6 @@ class m230101_100000_ConvertTextToJsonColumns extends Migration
 {
     public function safeUp(): bool
     {
-        $this->alterColumn('{{%freeform_forms}}', 'layoutJson', $this->json());
         $this->alterColumn('{{%freeform_forms}}', 'metadata', $this->json());
 
         $this->alterColumn('{{%freeform_export_profiles}}', 'fields', $this->json());
@@ -28,7 +27,6 @@ class m230101_100000_ConvertTextToJsonColumns extends Migration
 
     public function safeDown(): bool
     {
-        $this->alterColumn('{{%freeform_forms}}', 'layoutJson', $this->mediumText());
         $this->alterColumn('{{%freeform_forms}}', 'metadata', $this->mediumText());
 
         $this->alterColumn('{{%freeform_export_profiles}}', 'fields', $this->text());

--- a/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
+++ b/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
@@ -96,6 +96,8 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
                 ['metadata' => $metadata],
                 ['id' => $id],
             );
+
+            $this->dropColumn('{{%freeform_forms}}', 'layoutJson');
         }
 
         return true;

--- a/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
+++ b/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
@@ -96,8 +96,6 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
                 ['metadata' => $metadata],
                 ['id' => $id],
             );
-
-            $this->dropColumn('{{%freeform_forms}}', 'layoutJson');
         }
 
         return true;


### PR DESCRIPTION
Fixes the follows migration errors

```
*** applying m230101_100000_ConvertTextToJsonColumns
    > alter column layoutJson in table {{%freeform_forms}} to json ...Exception: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'layoutJson' in 'freeform_forms'
```