### PR TITLE
[SFT-813]: Moving fields around in the layout causes data loss for Text-type fields

### DIFF
--- a/packages/plugin/src/migrations/Install.php
+++ b/packages/plugin/src/migrations/Install.php
@@ -55,11 +55,11 @@ class Install extends StreamlinedInstallMigration
                 ->addField('formId', $this->integer()->notNull())
                 ->addField('type', $this->string(255)->notNull())
                 ->addField('metadata', $this->json())
-                ->addField('rowId', $this->integer()->notNull())
+                ->addField('rowId', $this->integer())
                 ->addField('order', $this->integer())
                 ->addIndex(['rowId', 'order'])
                 ->addForeignKey('formId', 'freeform_forms', 'id', ForeignKey::CASCADE)
-                ->addForeignKey('rowId', 'freeform_forms_rows', 'id', ForeignKey::CASCADE),
+                ->addForeignKey('rowId', 'freeform_forms_rows', 'id', ForeignKey::SET_NULL),
 
             (new Table('freeform_forms_integrations'))
                 ->addField('id', $this->primaryKey())

--- a/packages/plugin/src/migrations/m240110_111258_ChangeFormFieldRowForeignKey.php
+++ b/packages/plugin/src/migrations/m240110_111258_ChangeFormFieldRowForeignKey.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+
+class m240110_111258_ChangeFormFieldRowForeignKey extends Migration
+{
+    public function safeUp(): bool
+    {
+        $table = $this->db->getTableSchema('{{%freeform_forms_fields}}', true);
+        foreach ($table->foreignKeys as $key => $foreignKey) {
+            if (!str_contains($foreignKey[0], 'freeform_forms_rows')) {
+                continue;
+            }
+
+            if (!isset($foreignKey['rowId']) || 'id' !== $foreignKey['rowId']) {
+                continue;
+            }
+
+            $this->dropForeignKey($key, '{{%freeform_forms_fields}}');
+
+            $this->alterColumn(
+                '{{%freeform_forms_fields}}',
+                'rowId',
+                $this->integer()->null()
+            );
+
+            $this->addForeignKey(
+                null,
+                '{{%freeform_forms_fields}}',
+                'rowId',
+                '{{%freeform_forms_rows}}',
+                'id',
+                'SET NULL'
+            );
+
+            break;
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        echo "m240110_111258_ChangeFormFieldRowForeignKey cannot be reverted.\n";
+
+        return false;
+    }
+}


### PR DESCRIPTION
### Description

* fixed an issue where field data would be wiped from submissions when changing fields between rows