### PR TITLE
[SFT-866]: removing all old integrations on `4 -> 5` migration

### DIFF
--- a/packages/plugin/src/migrations/m230101_100050_FF4to5_MigrateIntegrations.php
+++ b/packages/plugin/src/migrations/m230101_100050_FF4to5_MigrateIntegrations.php
@@ -40,6 +40,8 @@ class m230101_100050_FF4to5_MigrateIntegrations extends Migration
             'CASCADE',
         );
 
+        $this->delete('{{%freeform_integrations}}');
+
         return true;
     }
 


### PR DESCRIPTION
* when migrating from FF4 to FF5 - removing any integrations in the `freeform_integrations` table