### PR TITLE
[SFT-877]: Element query executed before Craft is fully initialized

### DIFF
--- a/packages/plugin/src/Bundles/Persistence/FormPersistence.php
+++ b/packages/plugin/src/Bundles/Persistence/FormPersistence.php
@@ -2,7 +2,6 @@
 
 namespace Solspace\Freeform\Bundles\Persistence;
 
-use craft\elements\User;
 use Solspace\Freeform\Bundles\Attributes\Form\SettingsProvider;
 use Solspace\Freeform\controllers\api\FormsController;
 use Solspace\Freeform\Events\Forms\PersistFormEvent;
@@ -15,14 +14,10 @@ use yii\base\Event;
 
 class FormPersistence extends FeatureBundle
 {
-    private ?User $user;
-
     public function __construct(
         private FormsService $formsService,
         private SettingsProvider $settingsProvider,
     ) {
-        $this->user = \Craft::$app->getUser()->getIdentity();
-
         Event::on(
             FormsController::class,
             FormsController::EVENT_CREATE_FORM,
@@ -61,7 +56,8 @@ class FormPersistence extends FeatureBundle
         $record->uid = $payload->uid;
         $record->type = $payload->type;
 
-        $record->createdByUserId = $this->user->id;
+        $user = \Craft::$app->getUser()->getIdentity();
+        $record->createdByUserId = $user->id;
 
         $this->update($event, $record);
     }
@@ -82,7 +78,9 @@ class FormPersistence extends FeatureBundle
 
         $record->metadata = $this->getValidatedMetadata($payload, $event);
         $record->type = $record->metadata['general']->type ?? Regular::class;
-        $record->updatedByUserId = $this->user->id;
+
+        $user = \Craft::$app->getUser()->getIdentity();
+        $record->updatedByUserId = $user->id;
 
         if (!$event->hasErrors()) {
             $record->validate();


### PR DESCRIPTION
### Description
Warnings were logged for executing query before Craft is fully initialized.
It was caused by the `FormPersistance` feature, trying to fetch the current user in its Constructor.

* moved user lookup to event methods, to prevent the issue