### PR TITLE
[SFT-876]: Send digest mail added to queue even when turned off

### DIFF
--- a/packages/plugin/src/Bundles/Digest/DigestBundle.php
+++ b/packages/plugin/src/Bundles/Digest/DigestBundle.php
@@ -36,8 +36,16 @@ class DigestBundle extends FeatureBundle
             return;
         }
 
-        $job = new SendDigestJob(new Carbon('now'));
+        $settings = $this->plugin()->settings;
 
+        $devRecipients = $settings->getDigestRecipients();
+        $clientRecipients = $settings->getClientDigestRecipients();
+
+        if (!$devRecipients->count() && !$clientRecipients->count()) {
+            return;
+        }
+
+        $job = new SendDigestJob(new Carbon('now'));
         \Craft::$app->getQueue()->push($job);
     }
 }


### PR DESCRIPTION
### Description
Digest jobs were being added no matter your preferences. Now if there are no recipients defined, the job does not get added.