### PR TITLE
[SFT-894]: The Dynamic Recipients field does not correctly select the option chosen when viewing in the CP Submission detail page

### DIFF
--- a/packages/plugin/src/Library/Composer/Components/Fields/Traits/OptionsKeyValuePairTrait.php
+++ b/packages/plugin/src/Library/Composer/Components/Fields/Traits/OptionsKeyValuePairTrait.php
@@ -7,14 +7,18 @@ use Solspace\Freeform\Library\Composer\Components\Fields\DataContainers\Option;
 
 trait OptionsKeyValuePairTrait
 {
-    public function getOptionsAsKeyValuePairs(): array
+    public function getOptionsAsKeyValuePairs(bool $forceLabels = false): array
     {
         $pairs = [];
 
         if ($this instanceof DynamicRecipientField) {
             /** @var Option $option */
             foreach ($this->getOptions() as $index => $option) {
-                $pairs[$option->getValue()] = $option->getLabel();
+                if ($forceLabels) {
+                    $pairs[$option->getValue()] = $option->getLabel();
+                } else {
+                    $pairs[$index] = $option->getLabel();
+                }
             }
         } else {
             /** @var Option $option */

--- a/packages/plugin/src/Library/Export/AbstractExport.php
+++ b/packages/plugin/src/Library/Export/AbstractExport.php
@@ -138,7 +138,7 @@ abstract class AbstractExport implements ExportInterface
                     }
 
                     if ($this->exportLabels && $field instanceof OptionsInterface) {
-                        $options = $field->getOptionsAsKeyValuePairs();
+                        $options = $field->getOptionsAsKeyValuePairs(true);
 
                         if (\is_array($value)) {
                             foreach ($value as $index => $val) {


### PR DESCRIPTION
* fixing dynamic recipient value display in submissions view CP