### PR TITLE
[SFT-884][fix]: `attributes` overrides in templates and subsequent requests

### DIFF
--- a/packages/plugin/src/Attributes/Property/Implementations/Options/OptionCollection.php
+++ b/packages/plugin/src/Attributes/Property/Implementations/Options/OptionCollection.php
@@ -137,7 +137,7 @@ class OptionCollection implements CustomNormalizerInterface, \IteratorAggregate,
         throw new \BadMethodCallException('OptionCollection is read-only');
     }
 
-    public function offsetUnset(mixed $offset)
+    public function offsetUnset(mixed $offset): void
     {
         throw new \BadMethodCallException('OptionCollection is read-only');
     }

--- a/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
+++ b/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\Fields;
 
-use Solspace\Freeform\Events\Fields\FieldPropertiesEvent;
+use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
@@ -13,12 +13,12 @@ class FieldContainerBundle extends FeatureBundle
     {
         Event::on(
             FieldInterface::class,
-            FieldInterface::EVENT_AFTER_SET_PROPERTIES,
+            FieldInterface::EVENT_COMPILE_ATTRIBUTES,
             [$this, 'updateContainerAttributes'],
         );
     }
 
-    public function updateContainerAttributes(FieldPropertiesEvent $event): void
+    public function updateContainerAttributes(CompileAttributesEvent $event): void
     {
         $request = \Craft::$app->request;
         if ($request && $request->isCpRequest) {
@@ -32,7 +32,7 @@ class FieldContainerBundle extends FeatureBundle
         }
 
         $field = $event->getField();
-        $field
+        $event
             ->getAttributes()
             ->getContainer()
             ->replace('data-field-container', $field->getHandle())

--- a/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
+++ b/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\Fields;
 
-use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
+use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
@@ -18,7 +18,7 @@ class FieldContainerBundle extends FeatureBundle
         );
     }
 
-    public function updateContainerAttributes(CompileAttributesEvent $event): void
+    public function updateContainerAttributes(CompileFieldAttributesEvent $event): void
     {
         $request = \Craft::$app->request;
         if ($request && $request->isCpRequest) {

--- a/packages/plugin/src/Bundles/Fields/FieldRenderOptionsBundle.php
+++ b/packages/plugin/src/Bundles/Fields/FieldRenderOptionsBundle.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\Fields;
 
-use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
+use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Events\Fields\SetParametersEvent;
 use Solspace\Freeform\Events\Forms\SetPropertiesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
@@ -40,7 +40,7 @@ class FieldRenderOptionsBundle extends FeatureBundle
         );
     }
 
-    public function compileAttributes(CompileAttributesEvent $event): void
+    public function compileAttributes(CompileFieldAttributesEvent $event): void
     {
         $field = $event->getField();
         $form = $field->getForm();

--- a/packages/plugin/src/Bundles/Fields/FieldRenderOptionsBundle.php
+++ b/packages/plugin/src/Bundles/Fields/FieldRenderOptionsBundle.php
@@ -3,22 +3,30 @@
 namespace Solspace\Freeform\Bundles\Fields;
 
 use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
+use Solspace\Freeform\Events\Fields\SetParametersEvent;
 use Solspace\Freeform\Events\Forms\SetPropertiesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Form\Form;
+use Solspace\Freeform\Library\Attributes\Attributes;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
+use Solspace\Freeform\Library\Helpers\ReflectionHelper;
 use Solspace\Freeform\Library\Processors\FieldRenderOptionProcessor;
 use yii\base\Event;
 
 class FieldRenderOptionsBundle extends FeatureBundle
 {
-    private const KEY_FIELD_PROPERTIES = 'fields';
-    private const KEY_FIELD_PROPERTY_STACK = 'fieldPropertiesStack';
-
-    private array $attributeCache = [];
+    private const KEY_FORM_FIELD_PROPERTIES = 'fields';
+    private const KEY_FORM_PROPERTY_STACK = 'formPropertyStack';
+    private const KEY_FIELDS_PROPERTY_STACK = 'fieldsPropertyStack';
 
     public function __construct()
     {
+        Event::on(
+            FieldInterface::class,
+            FieldInterface::EVENT_COMPILE_ATTRIBUTES,
+            [$this, 'compileAttributes']
+        );
+
         Event::on(
             Form::class,
             Form::EVENT_SET_PROPERTIES,
@@ -27,8 +35,8 @@ class FieldRenderOptionsBundle extends FeatureBundle
 
         Event::on(
             FieldInterface::class,
-            FieldInterface::EVENT_COMPILE_ATTRIBUTES,
-            [$this, 'compileAttributes']
+            FieldInterface::EVENT_SET_PARAMETERS,
+            [$this, 'onSetParameters']
         );
     }
 
@@ -38,55 +46,108 @@ class FieldRenderOptionsBundle extends FeatureBundle
         $form = $field->getForm();
 
         $bag = $form->getProperties();
-        $stack = $bag->get(self::KEY_FIELD_PROPERTY_STACK);
-        if (!$stack) {
+        $formStack = $bag->get(self::KEY_FORM_PROPERTY_STACK) ?? [];
+        $fieldsStack = $bag->get(self::KEY_FIELDS_PROPERTY_STACK)[$field->getId()] ?? [];
+
+        if (!$formStack && !$fieldsStack) {
             return;
         }
 
-        $cacheKey = md5(json_encode($stack)).'-'.$field->getId();
-        if (!isset($this->attributeCache[$cacheKey])) {
-            $attributes = $event->getAttributes()->clone();
-            $processor = new FieldRenderOptionProcessor();
+        $attributes = $event->getAttributes();
+        $processor = new FieldRenderOptionProcessor();
 
-            $stack = array_reverse($stack);
-            foreach ($stack as $item) {
-                $processor->processAttributes($item, $field, $attributes);
-            }
-
-            $this->attributeCache[$cacheKey] = $attributes;
+        foreach ($fieldsStack as $item) {
+            $processor->processAttributes(['@global' => $item], $field, $attributes);
+            $processor->processProperties(['@global' => $item], $field);
         }
 
-        $event->setAttributes($this->attributeCache[$cacheKey]);
+        $formStack = array_reverse($formStack);
+        foreach ($formStack as $item) {
+            $processor->processAttributes($item, $field, $attributes);
+            $processor->processProperties($item, $field);
+        }
+
+        $event->setAttributes($attributes);
     }
 
     public function processOptions(SetPropertiesEvent $event): void
     {
         $properties = $event->getProperties();
-        if (!isset($properties[self::KEY_FIELD_PROPERTIES])) {
+        if (!isset($properties[self::KEY_FORM_FIELD_PROPERTIES])) {
             return;
         }
 
-        $props = $properties[self::KEY_FIELD_PROPERTIES];
+        $props = $properties[self::KEY_FORM_FIELD_PROPERTIES];
 
         // Get the current property stack and add to the stack
         $form = $event->getForm();
-        $stack = $form->getProperties()->get(self::KEY_FIELD_PROPERTY_STACK, []);
+        $stack = $form->getProperties()->get(self::KEY_FORM_PROPERTY_STACK, []);
         foreach ($stack as $stackItem) {
             if ($stackItem === $props) {
                 return;
             }
         }
 
-        $processor = new FieldRenderOptionProcessor();
-        foreach ($form->getFields() as $field) {
-            $processor->processProperties($props, $field);
-        }
-
         $stack[] = $props;
-        $form->getProperties()->set(self::KEY_FIELD_PROPERTY_STACK, $stack);
+        $form->getProperties()->set(self::KEY_FORM_PROPERTY_STACK, $stack);
 
         // Remove from current properties
-        unset($properties[self::KEY_FIELD_PROPERTIES]);
+        unset($properties[self::KEY_FORM_FIELD_PROPERTIES]);
         $event->setProperties($properties);
+    }
+
+    public function onSetParameters(SetParametersEvent $event): void
+    {
+        $field = $event->getField();
+        $parameters = $event->getParameters();
+
+        if (empty($parameters)) {
+            return;
+        }
+
+        $form = $field->getForm();
+
+        $fieldAttributes = $form->getProperties()->get(self::KEY_FIELDS_PROPERTY_STACK, []);
+        $stack = $fieldAttributes[$field->getId()] ?? [];
+        foreach ($stack as $item) {
+            if ($item === $parameters) {
+                return;
+            }
+        }
+
+        $cleanParameters = [];
+        $attributes = [];
+
+        foreach ($parameters as $key => $value) {
+            try {
+                $property = new \ReflectionProperty($field, $key);
+
+                $type = $property->getType()?->getName();
+                if ($type) {
+                    if (ReflectionHelper::isInstanceOf($type, Attributes::class)) {
+                        $attributes[$key] = $value;
+                        unset($parameters[$key]);
+
+                        continue;
+                    }
+                }
+            } catch (\ReflectionException $e) {
+            }
+
+            $cleanParameters[$key] = $value;
+        }
+
+        $stack[] = $attributes;
+        $stack = array_filter($stack);
+
+        $fieldAttributes[$field->getId()] = $stack;
+        $fieldAttributes = array_filter($fieldAttributes);
+
+        $form->getProperties()->set(self::KEY_FIELDS_PROPERTY_STACK, $fieldAttributes);
+
+        $processor = new FieldRenderOptionProcessor();
+        $processor->processProperties(['@global' => $cleanParameters], $field);
+
+        $event->setParameters($cleanParameters);
     }
 }

--- a/packages/plugin/src/Bundles/Form/Context/Session/SessionContext.php
+++ b/packages/plugin/src/Bundles/Form/Context/Session/SessionContext.php
@@ -12,6 +12,7 @@ use Solspace\Freeform\Bundles\Form\Context\Session\StorageTypes\SessionStorage;
 use Solspace\Freeform\Bundles\Form\SaveForm\Events\SaveFormEvent;
 use Solspace\Freeform\Bundles\Form\SaveForm\SaveForm;
 use Solspace\Freeform\Events\FormEventInterface;
+use Solspace\Freeform\Events\Forms\ContextRetrievalEvent;
 use Solspace\Freeform\Events\Forms\HandleRequestEvent;
 use Solspace\Freeform\Events\Forms\RenderTagEvent;
 use Solspace\Freeform\Form\Form;
@@ -169,8 +170,15 @@ class SessionContext
 
         $form->getProperties()->merge($bag->getProperties());
         $form->getAttributes()->merge($bag->getAttributes());
+
         $form->setFormPosted(self::isFormPosted($form));
         $form->setPagePosted(self::isPagePosted($form, $form->getCurrentPageIndex()));
+
+        Event::trigger(
+            Form::class,
+            Form::EVENT_CONTEXT_RETRIEVAL,
+            new ContextRetrievalEvent($form, $bag)
+        );
     }
 
     public function storeContext(FormEventInterface $event): void

--- a/packages/plugin/src/Bundles/Form/Context/Session/StorageTypes/PayloadStorage.php
+++ b/packages/plugin/src/Bundles/Form/Context/Session/StorageTypes/PayloadStorage.php
@@ -28,7 +28,7 @@ class PayloadStorage implements FormContextStorageInterface
         $this->secret = $secret;
 
         Event::on(Form::class, Form::EVENT_GET_CUSTOM_PROPERTY, [$this, 'attachProperty']);
-        Event::on(Form::class, Form::EVENT_RENDER_AFTER_OPEN_TAG, [$this, 'attachInput']);
+        Event::on(Form::class, Form::EVENT_RENDER_BEFORE_CLOSING_TAG, [$this, 'attachInput']);
         Event::on(Form::class, Form::EVENT_OUTPUT_AS_JSON, [$this, 'attachJson']);
         Event::on(Form::class, Form::EVENT_PREPARE_AJAX_RESPONSE_PAYLOAD, [$this, 'attachToAjaxResponse']);
         Event::on(Form::class, Form::EVENT_BEFORE_HANDLE_REQUEST, [$this, 'requirePayload']);

--- a/packages/plugin/src/Bundles/Form/SubmitButtons/SubmitButtons.php
+++ b/packages/plugin/src/Bundles/Form/SubmitButtons/SubmitButtons.php
@@ -59,11 +59,11 @@ class SubmitButtons extends FeatureBundle
         $page = $form->getCurrentPage();
 
         $buttons = $page->getButtons();
+        $attributes = $buttons->getAttributes()->clone();
 
         $renderOptions = $form->getProperties()->get('buttons', []);
-        $this->processor->process($renderOptions, $buttons);
+        $this->processor->process($renderOptions, $buttons, $attributes);
 
-        $attributes = $buttons->getAttributes()->clone();
         $layout = $buttons->getParsedLayout();
 
         $containerAttributes = $attributes

--- a/packages/plugin/src/Bundles/Form/SubmitButtons/SubmitButtons.php
+++ b/packages/plugin/src/Bundles/Form/SubmitButtons/SubmitButtons.php
@@ -2,22 +2,32 @@
 
 namespace Solspace\Freeform\Bundles\Form\SubmitButtons;
 
-use craft\helpers\ArrayHelper;
+use Solspace\Freeform\Events\Fields\CompileButtonAttributesEvent;
 use Solspace\Freeform\Events\Forms\RenderTagEvent;
 use Solspace\Freeform\Events\Forms\SetPropertiesEvent;
 use Solspace\Freeform\Form\Form;
+use Solspace\Freeform\Form\Layout\Page\Buttons\PageButtons;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use Solspace\Freeform\Library\Processors\PageButtonRenderOptionProcessor;
 use yii\base\Event;
 
 class SubmitButtons extends FeatureBundle
 {
+    public const KEY_FORM_BUTTON_PROPERTIES = 'buttons';
+    public const KEY_FORM_BUTTON_PROPERTY_STACK = 'buttonPropertyStack';
+
     public function __construct(private PageButtonRenderOptionProcessor $processor)
     {
         Event::on(
             Form::class,
             Form::EVENT_SET_PROPERTIES,
             [$this, 'processOptions']
+        );
+
+        Event::on(
+            PageButtons::class,
+            PageButtons::EVENT_COMPILE_ATTRIBUTES,
+            [$this, 'compileAttributes']
         );
 
         Event::on(
@@ -29,20 +39,54 @@ class SubmitButtons extends FeatureBundle
 
     public function processOptions(SetPropertiesEvent $event): void
     {
-        $form = $event->getForm();
         $properties = $event->getProperties();
-
-        $buttonProperties = $form->getProperties()->get('buttons', []);
-
-        if (!isset($properties['buttons'])) {
+        if (!isset($properties[self::KEY_FORM_BUTTON_PROPERTIES])) {
             return;
         }
 
-        $buttonProperties = ArrayHelper::merge($buttonProperties, $properties['buttons']);
-        $form->getProperties()->merge(['buttons' => $buttonProperties]);
+        $props = $properties[self::KEY_FORM_BUTTON_PROPERTIES];
 
-        unset($properties['buttons']);
+        // Get the current property stack and add to the stack
+        $form = $event->getForm();
+        $stack = $form->getProperties()->get(self::KEY_FORM_BUTTON_PROPERTY_STACK, []);
+        foreach ($stack as $stackItem) {
+            if ($stackItem === $props) {
+                return;
+            }
+        }
+
+        $stack[] = $props;
+        $form->getProperties()->set(self::KEY_FORM_BUTTON_PROPERTY_STACK, $stack);
+
+        // Remove from current properties
+        unset($properties[self::KEY_FORM_BUTTON_PROPERTIES]);
         $event->setProperties($properties);
+    }
+
+    public function compileAttributes(CompileButtonAttributesEvent $event): void
+    {
+        $buttons = $event->sender;
+        if (!$buttons instanceof PageButtons) {
+            return;
+        }
+
+        $form = $buttons->getPage()->getForm();
+
+        $bag = $form->getProperties();
+        $stack = $bag->get(self::KEY_FORM_BUTTON_PROPERTY_STACK) ?? [];
+        if (!$stack) {
+            return;
+        }
+
+        $attributes = $event->getAttributes();
+        $processor = new PageButtonRenderOptionProcessor();
+
+        $stack = array_reverse($stack);
+        foreach ($stack as $item) {
+            $processor->process($item, $buttons, $attributes);
+        }
+
+        $event->setAttributes($attributes);
     }
 
     public function renderButtons(RenderTagEvent $event): void

--- a/packages/plugin/src/Events/Fields/CompileAttributesEvent.php
+++ b/packages/plugin/src/Events/Fields/CompileAttributesEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Solspace\Freeform\Events\Fields;
+
+use Solspace\Freeform\Fields\FieldInterface;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
+use yii\base\Event;
+
+class CompileAttributesEvent extends Event
+{
+    public function __construct(
+        private FieldInterface $field,
+        private FieldAttributesCollection $attributes,
+    ) {
+        parent::__construct();
+    }
+
+    public function getField(): FieldInterface
+    {
+        return $this->field;
+    }
+
+    public function getAttributes(): FieldAttributesCollection
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(FieldAttributesCollection $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+}

--- a/packages/plugin/src/Events/Fields/CompileButtonAttributesEvent.php
+++ b/packages/plugin/src/Events/Fields/CompileButtonAttributesEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Solspace\Freeform\Events\Fields;
+
+use Solspace\Freeform\Form\Layout\Page\Buttons\ButtonAttributesCollection;
+use Solspace\Freeform\Form\Layout\Page\Buttons\PageButtons;
+use yii\base\Event;
+
+class CompileButtonAttributesEvent extends Event
+{
+    public function __construct(
+        private PageButtons $buttons,
+        private ButtonAttributesCollection $attributes,
+    ) {
+        parent::__construct();
+    }
+
+    public function getButtons(): PageButtons
+    {
+        return $this->buttons;
+    }
+
+    public function getAttributes(): ButtonAttributesCollection
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(ButtonAttributesCollection $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+}

--- a/packages/plugin/src/Events/Fields/CompileFieldAttributesEvent.php
+++ b/packages/plugin/src/Events/Fields/CompileFieldAttributesEvent.php
@@ -6,7 +6,7 @@ use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use yii\base\Event;
 
-class CompileAttributesEvent extends Event
+class CompileFieldAttributesEvent extends Event
 {
     public function __construct(
         private FieldInterface $field,

--- a/packages/plugin/src/Events/Fields/SetParametersEvent.php
+++ b/packages/plugin/src/Events/Fields/SetParametersEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Solspace\Freeform\Events\Fields;
+
+use Solspace\Freeform\Fields\FieldInterface;
+use yii\base\Event;
+
+class SetParametersEvent extends Event
+{
+    public function __construct(
+        private FieldInterface $field,
+        private array $parameters,
+    ) {
+        parent::__construct();
+    }
+
+    public function getField(): FieldInterface
+    {
+        return $this->field;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function setParameters(array $parameters): self
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+}

--- a/packages/plugin/src/Events/Forms/ContextRetrievalEvent.php
+++ b/packages/plugin/src/Events/Forms/ContextRetrievalEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Solspace\Freeform\Events\Forms;
+
+use Solspace\Freeform\Bundles\Form\Context\Session\Bag\SessionBag;
+use Solspace\Freeform\Events\FormEventInterface;
+use Solspace\Freeform\Form\Form;
+use yii\base\Event;
+
+class ContextRetrievalEvent extends Event implements FormEventInterface
+{
+    public function __construct(private Form $form, private SessionBag $bag)
+    {
+        parent::__construct();
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
+    }
+
+    public function getBag(): SessionBag
+    {
+        return $this->bag;
+    }
+}

--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -640,7 +640,7 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
         $attributes = $this->getAttributes()
             ->getError()
             ->clone()
-            ->append('class', 'errors')
+            ->setIfEmpty('class', 'errors')
         ;
 
         $output = '<ul'.$attributes.'>';

--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -23,6 +23,7 @@ use Solspace\Freeform\Attributes\Property\Section;
 use Solspace\Freeform\Attributes\Property\Validators;
 use Solspace\Freeform\Attributes\Property\ValueTransformer;
 use Solspace\Freeform\Bundles\Fields\ImplementationProvider;
+use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
 use Solspace\Freeform\Events\Fields\FieldRenderEvent;
 use Solspace\Freeform\Events\Fields\ValidateEvent;
 use Solspace\Freeform\Fields\Interfaces\InputOnlyInterface;
@@ -412,7 +413,10 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
 
     public function getAttributes(): FieldAttributesCollection
     {
-        return $this->attributes;
+        $event = new CompileAttributesEvent($this, $this->attributes);
+        Event::trigger($this, self::EVENT_COMPILE_ATTRIBUTES, $event);
+
+        return $event->getAttributes();
     }
 
     public function getParameters(): Parameters

--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -23,7 +23,7 @@ use Solspace\Freeform\Attributes\Property\Section;
 use Solspace\Freeform\Attributes\Property\Validators;
 use Solspace\Freeform\Attributes\Property\ValueTransformer;
 use Solspace\Freeform\Bundles\Fields\ImplementationProvider;
-use Solspace\Freeform\Events\Fields\CompileAttributesEvent;
+use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Events\Fields\FieldRenderEvent;
 use Solspace\Freeform\Events\Fields\SetParametersEvent;
 use Solspace\Freeform\Events\Fields\ValidateEvent;
@@ -414,7 +414,7 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
 
     public function getAttributes(): FieldAttributesCollection
     {
-        $event = new CompileAttributesEvent($this, $this->attributes->clone());
+        $event = new CompileFieldAttributesEvent($this, $this->attributes->clone());
         Event::trigger($this, self::EVENT_COMPILE_ATTRIBUTES, $event);
 
         return $event->getAttributes();

--- a/packages/plugin/src/Fields/FieldInterface.php
+++ b/packages/plugin/src/Fields/FieldInterface.php
@@ -31,6 +31,7 @@ interface FieldInterface
     public const EVENT_RENDER_LABEL = 'render-label';
     public const EVENT_RENDER_ERRORS = 'render-errors';
     public const EVENT_RENDER_INSTRUCTIONS = 'render-instructions';
+    public const EVENT_COMPILE_ATTRIBUTES = 'compile-attributes';
 
     public const EVENT_VALIDATE = 'validate';
     public const EVENT_AFTER_SET_PROPERTIES = 'after-set-properties';

--- a/packages/plugin/src/Fields/FieldInterface.php
+++ b/packages/plugin/src/Fields/FieldInterface.php
@@ -32,6 +32,7 @@ interface FieldInterface
     public const EVENT_RENDER_ERRORS = 'render-errors';
     public const EVENT_RENDER_INSTRUCTIONS = 'render-instructions';
     public const EVENT_COMPILE_ATTRIBUTES = 'compile-attributes';
+    public const EVENT_SET_PARAMETERS = 'set-parameters';
 
     public const EVENT_VALIDATE = 'validate';
     public const EVENT_AFTER_SET_PROPERTIES = 'after-set-properties';

--- a/packages/plugin/src/Fields/Implementations/Pro/FileDragAndDropField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/FileDragAndDropField.php
@@ -76,13 +76,18 @@ class FileDragAndDropField extends FileUploadField implements ExtraFieldInterfac
             ['maxFileSize' => $this->getMaxFileSizeKB()]
         );
 
+        $fileCount = 0;
+        if (is_countable($this->getValue())) {
+            $fileCount = \count($this->getValue());
+        }
+
         $attributes = $this->getAttributes()
             ->getInput()
             ->clone()
             ->append('class', 'freeform-file-dnd__input')
             ->replace('data-freeform-file-upload', $this->getHandle())
             ->setIfEmpty('data-error-append-target', $this->getHandle())
-            ->replace('data-file-count', \count($this->getValue() ?? []))
+            ->replace('data-file-count', $fileCount)
             ->replace('data-max-files', $this->getFileCount())
             ->replace('data-max-size', $this->getMaxFileSizeBytes())
             ->setIfEmpty('data-theme', $this->getTheme())

--- a/packages/plugin/src/Form/Form.php
+++ b/packages/plugin/src/Form/Form.php
@@ -93,6 +93,7 @@ abstract class Form implements FormTypeInterface, \IteratorAggregate, CustomNorm
     public const EVENT_SEND_NOTIFICATIONS = 'send-notifications';
     public const EVENT_GET_CUSTOM_PROPERTY = 'get-custom-property';
     public const EVENT_QUICK_LOAD = 'quick-load';
+    public const EVENT_CONTEXT_RETRIEVAL = 'context-retrieval';
 
     public const PROPERTY_STORED_VALUES = 'storedValues';
     public const PROPERTY_PAGE_INDEX = 'pageIndex';

--- a/packages/plugin/src/Form/Layout/Page.php
+++ b/packages/plugin/src/Form/Layout/Page.php
@@ -3,6 +3,7 @@
 namespace Solspace\Freeform\Form\Layout;
 
 use Solspace\Freeform\Bundles\Attributes\Property\PropertyProvider;
+use Solspace\Freeform\Form\Form;
 use Solspace\Freeform\Form\Layout\Page\Buttons\PageButtons;
 use Solspace\Freeform\Library\Collections\FieldCollection;
 use Solspace\Freeform\Library\Collections\RowCollection;
@@ -20,6 +21,7 @@ class Page implements \IteratorAggregate
     private PageButtons $buttons;
 
     public function __construct(
+        private Form $form,
         private PropertyProvider $propertyProvider,
         private Layout $layout,
         array $config = [],
@@ -29,10 +31,15 @@ class Page implements \IteratorAggregate
         $this->label = $config['label'] ?? '';
         $this->index = $config['index'] ?? 0;
 
-        $buttons = new PageButtons([]);
+        $buttons = new PageButtons($this, []);
         $this->propertyProvider->setObjectProperties($buttons, $config['metadata']['buttons'] ?? []);
 
         $this->buttons = $buttons;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
     }
 
     public function getId(): ?int

--- a/packages/plugin/src/Library/Attributes/Attributes.php
+++ b/packages/plugin/src/Library/Attributes/Attributes.php
@@ -3,6 +3,7 @@
 namespace Solspace\Freeform\Library\Attributes;
 
 use Solspace\Commons\Helpers\StringHelper;
+use Solspace\Freeform\Library\Helpers\ReflectionHelper;
 use Solspace\Freeform\Library\Serialization\Normalizers\CustomNormalizerInterface;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
@@ -66,6 +67,18 @@ class Attributes implements CustomNormalizerInterface, \Countable, \JsonSerializ
         }
 
         return ' '.implode(' ', $stringArray);
+    }
+
+    public function __clone(): void
+    {
+        $reflection = new \ReflectionClass($this);
+        foreach ($reflection->getProperties() as $property) {
+            $type = $property->getType();
+            $typeName = $type?->getName();
+            if (ReflectionHelper::isInstanceOf(self::class, $typeName)) {
+                $this->{$property->getName()} = $this->{$property->getName()}->clone();
+            }
+        }
     }
 
     public function get(string $name, mixed $default = null): mixed

--- a/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
@@ -38,8 +38,12 @@ abstract class AbstractOptionProcessor
         $attributes->merge($value);
     }
 
-    protected function processPropertyValue(\ReflectionClass $reflection, object $object, string $key, mixed $value): void
-    {
+    protected function processPropertyValue(
+        \ReflectionClass $reflection,
+        object $object,
+        string $key,
+        mixed $value
+    ): void {
         try {
             $property = $reflection->getProperty($key);
         } catch (\ReflectionException) {

--- a/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
@@ -16,8 +16,6 @@ abstract class AbstractOptionProcessor
         string $key,
         mixed $value
     ): void {
-        $property = null;
-
         try {
             $property = $reflection->getProperty($key);
         } catch (\ReflectionException $e) {
@@ -42,11 +40,9 @@ abstract class AbstractOptionProcessor
 
     protected function processPropertyValue(\ReflectionClass $reflection, object $object, string $key, mixed $value): void
     {
-        $property = null;
-
         try {
             $property = $reflection->getProperty($key);
-        } catch (\ReflectionException $e) {
+        } catch (\ReflectionException) {
             return;
         }
 
@@ -72,11 +68,14 @@ abstract class AbstractOptionProcessor
         }
 
         if ('value' === $key) {
-            $defaultValueProperty = $reflection->getProperty('defaultValue');
-            if ($defaultValueProperty) {
-                $defaultValueProperty->setAccessible(true);
-                $defaultValueProperty->setValue($object, $value);
-                $defaultValueProperty->setAccessible(false);
+            try {
+                $defaultValueProperty = $reflection->getProperty('defaultValue');
+                if ($defaultValueProperty) {
+                    $defaultValueProperty->setAccessible(true);
+                    $defaultValueProperty->setValue($object, $value);
+                    $defaultValueProperty->setAccessible(false);
+                }
+            } catch (\ReflectionException) {
             }
         }
 

--- a/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/AbstractOptionProcessor.php
@@ -3,7 +3,7 @@
 namespace Solspace\Freeform\Library\Processors;
 
 use Solspace\Freeform\Attributes\Property\ValueTransformer;
-use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
+use Solspace\Freeform\Library\Attributes\Attributes;
 use Solspace\Freeform\Library\Helpers\AttributeHelper;
 use Solspace\Freeform\Library\Helpers\ReflectionHelper;
 use yii\di\Container;
@@ -11,7 +11,7 @@ use yii\di\Container;
 abstract class AbstractOptionProcessor
 {
     protected function processAttributeValue(
-        FieldAttributesCollection $attributes,
+        Attributes $attributes,
         \ReflectionClass $reflection,
         string $key,
         mixed $value
@@ -28,7 +28,7 @@ abstract class AbstractOptionProcessor
 
         $isAttribute = ReflectionHelper::isInstanceOf(
             $property->getType()?->getName(),
-            FieldAttributesCollection::class,
+            Attributes::class,
         );
 
         if (!$isAttribute) {
@@ -52,7 +52,7 @@ abstract class AbstractOptionProcessor
 
         $isAttribute = ReflectionHelper::isInstanceOf(
             $property->getType()?->getName(),
-            FieldAttributesCollection::class,
+            Attributes::class,
         );
 
         if ($isAttribute) {

--- a/packages/plugin/src/Library/Processors/FieldRenderOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/FieldRenderOptionProcessor.php
@@ -4,11 +4,48 @@ namespace Solspace\Freeform\Library\Processors;
 
 use Solspace\Freeform\Bundles\Fields\ImplementationProvider;
 use Solspace\Freeform\Fields\FieldInterface;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 
 class FieldRenderOptionProcessor extends AbstractOptionProcessor
 {
-    public function process(array $renderOptions, FieldInterface $field): void
-    {
+    public function processProperties(
+        array $renderOptions,
+        FieldInterface $field,
+    ): void {
+        $matchedOptions = $this->getMatchedOptions($renderOptions, $field);
+        $fieldReflection = new \ReflectionClass($field);
+
+        foreach ($matchedOptions as $options) {
+            foreach ($options as $key => $value) {
+                $this->processPropertyValue($fieldReflection, $field, $key, $value);
+            }
+        }
+    }
+
+    public function processAttributes(
+        array $renderOptions,
+        FieldInterface $field,
+        FieldAttributesCollection $attributes
+    ): void {
+        $matchedOptions = $this->getMatchedOptions($renderOptions, $field);
+        $fieldReflection = new \ReflectionClass($field);
+
+        foreach ($matchedOptions as $options) {
+            foreach ($options as $key => $value) {
+                $this->processAttributeValue(
+                    $attributes,
+                    $fieldReflection,
+                    $key,
+                    $value,
+                );
+            }
+        }
+    }
+
+    private function getMatchedOptions(
+        array $renderOptions,
+        FieldInterface $field
+    ): array {
         $implementationProvider = new ImplementationProvider();
         $meta = [
             ':required' => $field->isRequired(),
@@ -52,12 +89,6 @@ class FieldRenderOptionProcessor extends AbstractOptionProcessor
             }
         }
 
-        $fieldReflection = new \ReflectionClass($field);
-
-        foreach ($matchedOptions as $options) {
-            foreach ($options as $key => $value) {
-                $this->processPropertyValue($fieldReflection, $field, $key, $value);
-            }
-        }
+        return $matchedOptions;
     }
 }

--- a/packages/plugin/src/Library/Processors/FieldRenderOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/FieldRenderOptionProcessor.php
@@ -4,7 +4,7 @@ namespace Solspace\Freeform\Library\Processors;
 
 use Solspace\Freeform\Bundles\Fields\ImplementationProvider;
 use Solspace\Freeform\Fields\FieldInterface;
-use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
+use Solspace\Freeform\Library\Attributes\Attributes;
 
 class FieldRenderOptionProcessor extends AbstractOptionProcessor
 {
@@ -25,7 +25,7 @@ class FieldRenderOptionProcessor extends AbstractOptionProcessor
     public function processAttributes(
         array $renderOptions,
         FieldInterface $field,
-        FieldAttributesCollection $attributes
+        Attributes $attributes
     ): void {
         $matchedOptions = $this->getMatchedOptions($renderOptions, $field);
         $fieldReflection = new \ReflectionClass($field);

--- a/packages/plugin/src/Library/Processors/PageButtonRenderOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/PageButtonRenderOptionProcessor.php
@@ -3,14 +3,16 @@
 namespace Solspace\Freeform\Library\Processors;
 
 use Solspace\Freeform\Form\Layout\Page\Buttons\PageButtons;
+use Solspace\Freeform\Library\Attributes\Attributes;
 
 class PageButtonRenderOptionProcessor extends AbstractOptionProcessor
 {
-    public function process(array $renderOptions, PageButtons $buttons): void
+    public function process(array $renderOptions, PageButtons $buttons, Attributes $attributes): void
     {
         $reflection = new \ReflectionClass($buttons);
 
         foreach ($renderOptions as $key => $value) {
+            $this->processAttributeValue($attributes, $reflection, $key, $value);
             $this->processPropertyValue($reflection, $buttons, $key, $value);
         }
     }

--- a/packages/plugin/src/Library/Processors/PageButtonRenderOptionProcessor.php
+++ b/packages/plugin/src/Library/Processors/PageButtonRenderOptionProcessor.php
@@ -7,8 +7,11 @@ use Solspace\Freeform\Library\Attributes\Attributes;
 
 class PageButtonRenderOptionProcessor extends AbstractOptionProcessor
 {
-    public function process(array $renderOptions, PageButtons $buttons, Attributes $attributes): void
-    {
+    public function process(
+        array $renderOptions,
+        PageButtons $buttons,
+        Attributes $attributes
+    ): void {
         $reflection = new \ReflectionClass($buttons);
 
         foreach ($renderOptions as $key => $value) {

--- a/packages/plugin/src/Services/Form/LayoutsService.php
+++ b/packages/plugin/src/Services/Form/LayoutsService.php
@@ -47,7 +47,7 @@ class LayoutsService extends BaseService
                 $pageData['index'] = $index;
                 $layout = new Layout($pageData['layoutUid']);
 
-                $page = new Page($this->propertyProvider, $layout, $pageData);
+                $page = new Page($form, $this->propertyProvider, $layout, $pageData);
                 $formLayout->getPages()->add($page);
 
                 $this->attachRows(
@@ -63,6 +63,7 @@ class LayoutsService extends BaseService
             if (empty($pages)) {
                 $formLayout->getPages()->add(
                     new Page(
+                        $form,
                         $this->propertyProvider,
                         new Layout(''),
                         ['label' => 'Page 1']

--- a/packages/plugin/src/Tests/Form/Layout/LayoutTest.php
+++ b/packages/plugin/src/Tests/Form/Layout/LayoutTest.php
@@ -4,6 +4,7 @@ namespace Solspace\Freeform\Tests\Form\Layout;
 
 use PHPUnit\Framework\TestCase;
 use Solspace\Freeform\Bundles\Attributes\Property\PropertyProvider;
+use Solspace\Freeform\Form\Form;
 use Solspace\Freeform\Form\Layout\FormLayout;
 use Solspace\Freeform\Form\Layout\Layout;
 use Solspace\Freeform\Form\Layout\Page;
@@ -16,18 +17,20 @@ use Solspace\Freeform\Form\Layout\Page;
 class LayoutTest extends TestCase
 {
     private PropertyProvider $propertyProvider;
+    private Form $formMock;
 
     protected function setUp(): void
     {
         $this->propertyProvider = $this->createMock(PropertyProvider::class);
+        $this->formMock = $this->createMock(Form::class);
     }
 
     public function testIteratePages()
     {
         $layout = new FormLayout();
         $layout->getPages()
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page One']))
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page Two']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page One']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page Two']))
         ;
 
         $labels = [];
@@ -42,8 +45,8 @@ class LayoutTest extends TestCase
     {
         $layout = new FormLayout();
         $layout->getPages()
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page One']))
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page Two']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page One']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page Two']))
         ;
 
         $this->assertCount(2, $layout);
@@ -53,8 +56,8 @@ class LayoutTest extends TestCase
     {
         $layout = new FormLayout();
         $layout->getPages()
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page One']))
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page Two']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page One']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page Two']))
         ;
 
         $this->assertSame('Page One', $layout->getPages()->getByIndex(0)->getLabel());
@@ -65,8 +68,8 @@ class LayoutTest extends TestCase
     {
         $layout = new FormLayout();
         $layout->getPages()
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page One']))
-            ->add(new Page($this->propertyProvider, new Layout(), ['label' => 'Page Two']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page One']))
+            ->add(new Page($this->formMock, $this->propertyProvider, new Layout(), ['label' => 'Page Two']))
         ;
 
         $buttons = $layout->getPages()->getByIndex(0)->getButtons();

--- a/packages/plugin/src/Tests/Library/Processors/FieldRenderOptionProcessorTest.php
+++ b/packages/plugin/src/Tests/Library/Processors/FieldRenderOptionProcessorTest.php
@@ -7,6 +7,8 @@ use Solspace\Freeform\Fields\Implementations\DropdownField;
 use Solspace\Freeform\Fields\Implementations\Pro\TableField;
 use Solspace\Freeform\Fields\Implementations\TextField;
 use Solspace\Freeform\Form\Form;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
+use Solspace\Freeform\Library\Attributes\TableAttributesCollection;
 use Solspace\Freeform\Library\Processors\FieldRenderOptionProcessor;
 use yii\di\Container;
 
@@ -71,8 +73,10 @@ class FieldRenderOptionProcessorTest extends TestCase
         $formMock = $this->createMock(Form::class);
         $field = new TextField($formMock);
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getInput();
+        $attributes = new FieldAttributesCollection();
+
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $output = (string) $attributes->getInput();
 
         $this->assertSame(
             ' class="one text-class dropdown-n-text table-n-text" placeholder="text-placeholder dropdown-placeholder"',
@@ -107,8 +111,11 @@ class FieldRenderOptionProcessorTest extends TestCase
 
         $field->method('getHandle')->willReturn('myTextField');
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getInput();
+        $attributes = new FieldAttributesCollection();
+
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $this->processor->processProperties($properties, $field);
+        $output = (string) $attributes->getInput();
 
         $this->assertSame(' class="one" id="my-text-field"', $output);
         $this->assertSame('test', $field->getValue());
@@ -133,9 +140,10 @@ class FieldRenderOptionProcessorTest extends TestCase
 
         $formMock = $this->createMock(Form::class);
         $field = new DropdownField($formMock);
+        $attributes = new FieldAttributesCollection();
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getInput();
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $output = (string) $attributes->getInput();
 
         $this->assertSame(' class="one options-field"', $output);
     }
@@ -171,8 +179,10 @@ class FieldRenderOptionProcessorTest extends TestCase
         $field->method('isRequired')->willReturn(true);
         $field->method('hasErrors')->willReturn(true);
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getLabel();
+        $attributes = new FieldAttributesCollection();
+
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $output = (string) $attributes->getLabel();
 
         $this->assertSame(' class="one required has-errors"', $output);
     }
@@ -208,8 +218,10 @@ class FieldRenderOptionProcessorTest extends TestCase
 
         $field->method('getHandle')->willReturn('myTextField');
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getLabel();
+        $attributes = new FieldAttributesCollection();
+
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $output = (string) $attributes->getLabel();
 
         $this->assertSame(' class="one"', $output);
     }
@@ -239,8 +251,10 @@ class FieldRenderOptionProcessorTest extends TestCase
         $field->method('getHandle')->willReturn('myTextField');
         $field->method('hasErrors')->willReturn(true);
 
-        $this->processor->process($properties, $field);
-        $output = (string) $field->getAttributes()->getLabel();
+        $attributes = new FieldAttributesCollection();
+
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $output = (string) $attributes->getLabel();
 
         $this->assertSame(' class="one combined"', $output);
     }
@@ -267,11 +281,14 @@ class FieldRenderOptionProcessorTest extends TestCase
 
         $formMock = $this->createMock(Form::class);
         $field = new TableField($formMock);
+        $attributes = new FieldAttributesCollection();
+        $tableAttributes = new TableAttributesCollection();
 
-        $this->processor->process($properties, $field);
+        $this->processor->processAttributes($properties, $field, $attributes);
+        $this->processor->processAttributes($properties, $field, $tableAttributes);
 
-        $output = (string) $field->getAttributes()->getLabel();
-        $tableOutput = (string) $field->getTableAttributes()->getRow();
+        $output = (string) $attributes->getLabel();
+        $tableOutput = (string) $tableAttributes->getRow();
 
         $this->assertSame(' class="one two"', $output);
         $this->assertSame(' test="value"', $tableOutput);

--- a/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
@@ -13,7 +13,6 @@
     },
     fields: {
         "@global": {
-            placeholder: 'test',
             attributes: {
                 input: {
                     novalidate: true,

--- a/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
@@ -13,6 +13,7 @@
     },
     fields: {
         "@global": {
+            placeholder: 'test',
             attributes: {
                 input: {
                     novalidate: true,


### PR DESCRIPTION
### Related Ticket Number

SFT-884

### Description

There was an issue with template overrides of field attributes when the form moves forward in pages. They weren't persisted in the order they were executed initially, so some attributes could go missing.

This is alleviated now by persisting each attribute override list in a stack, and re-executing them in the correct order upon context retrieval.

- implementing storage of attribute override stack
- iterating through the override stack in the same order on consequent form loads
