### PR TITLE
SFT-901 The Webhook URL for Stripe Payments is automatically generated with `/admin` in the URL

### DIFF
--- a/packages/plugin/src/Bundles/Attributes/Property/PropertyProvider.php
+++ b/packages/plugin/src/Bundles/Attributes/Property/PropertyProvider.php
@@ -66,6 +66,10 @@ class PropertyProvider
                 $value = $valueUpdateCallback($value, $editableProperty);
             }
 
+            if (null === $value && !$reflectionProperty->getType()?->allowsNull()) {
+                continue;
+            }
+
             $accessible = $reflectionProperty->isPublic();
 
             $reflectionProperty->setAccessible(true);

--- a/packages/plugin/src/Models/IntegrationModel.php
+++ b/packages/plugin/src/Models/IntegrationModel.php
@@ -96,6 +96,10 @@ class IntegrationModel extends Model
             return \Craft::$app->security->decryptByKey(base64_decode($value), $securityKey);
         }
 
+        if ($property->hasFlag(IntegrationInterface::FLAG_READONLY)) {
+            return null;
+        }
+
         return $value;
     }
 }

--- a/packages/plugin/src/Services/Integrations/IntegrationsService.php
+++ b/packages/plugin/src/Services/Integrations/IntegrationsService.php
@@ -304,6 +304,10 @@ class IntegrationsService extends BaseService
 
                 $model->metadata[$property->handle] = $value;
             }
+
+            if ($property->hasFlag(IntegrationInterface::FLAG_READONLY)) {
+                unset($model->metadata[$property->handle]);
+            }
         }
     }
 


### PR DESCRIPTION
### Related Ticket Number

SFT-901

### Description

Stripe was displaying the wrong URL for webhooks, and it was being saved in the DB.

- no longer persisting `readonly` values in the db
- fixing webhook URL path
