### PR TITLE
Fix table references when adding foreign keys

### DIFF
--- a/packages/plugin/src/migrations/Install.php
+++ b/packages/plugin/src/migrations/Install.php
@@ -371,14 +371,14 @@ class Install extends StreamlinedInstallMigration
             $this->addPrimaryKey('PRIMARY_KEY', '{{%freeform_rules_notifications}}', 'id');
         }
 
-        $this->addForeignKey(null, 'freeform_rules_fields', ['id'], 'freeform_rules', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_fields', ['fieldId'], 'freeform_forms_fields', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_pages', ['id'], 'freeform_rules', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_pages', ['pageId'], 'freeform_forms_pages', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_notifications', ['id'], 'freeform_rules', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_notifications', ['notificationId'], 'freeform_forms_notifications', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_rules_conditions', ['fieldId'], 'freeform_forms_fields', ['id'], 'CASCADE', 'CASCADE');
-        $this->addForeignKey(null, 'freeform_survey_preferences', ['fieldId'], 'freeform_forms_fields', ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, '{{%freeform_rules_fields}}', ['id'], '{{%freeform_rules}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_fields}}', ['fieldId'], '{{%freeform_forms_fields}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_pages}}', ['id'], '{{%freeform_rules}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_pages}}', ['pageId'], '{{%freeform_forms_pages}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_notifications}}', ['id'], '{{%freeform_rules}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_notifications}}', ['notificationId'], '{{%freeform_forms_notifications}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_rules_conditions}}', ['fieldId'], '{{%freeform_forms_fields}}', ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, '{{%freeform_survey_preferences}}', ['fieldId'], '{{%freeform_forms_fields}}', ['id'], 'CASCADE', null);
 
         return parent::afterInstall();
     }


### PR DESCRIPTION
Updates references to table names to use `{{%...}}` syntax to account for project where a table prefix is set. Fixes [#1054](https://github.com/solspace/craft-freeform/issues/1054)