### PR TITLE
[SFT-903]: fixing dynamic notification migration issue

### DIFF
--- a/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
+++ b/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
@@ -684,6 +684,7 @@ class m230101_200000_FF4to5_MigrateData extends Migration
             'enabled' => true,
             'field' => $record->uid,
             'template' => $notificationId,
+            'recipients' => [],
             'recipientMapping' => array_map(
                 fn ($option) => [
                     'value' => $option->label,


### PR DESCRIPTION
### Related Ticket Number

SFT-903

### Description

When migrating from Freeform 4 to Freeform 5, is you had any dynamic recipients fields, they would migrate all of the data, but it would be missing a `recipients => []` in the metadata JSON, which would trigger a `accessing uninitialized variable` error when triggering a form submit.

- adding `recipients` empty initializer data to the migration
