### PR TITLE
[SFT-904]: regex validator skips on empty values

### DIFF
--- a/packages/plugin/src/Bundles/Fields/Validation/RegexValidation.php
+++ b/packages/plugin/src/Bundles/Fields/Validation/RegexValidation.php
@@ -29,7 +29,7 @@ class RegexValidation extends FeatureBundle
 
         $value = $field->getValue();
         $pattern = $field->getPattern();
-        if (empty($pattern)) {
+        if (empty($pattern) || empty($value)) {
             return;
         }
 


### PR DESCRIPTION
### Related Ticket Number

SFT-904

### Description

If a user submits an empty value for a regex field, the regex validator would try to match the expression on the empty string and fail. 

- skipping regex validation on empty values
