### PR TITLE
fix(SFT-920) Migration fixes for skipped submissions tables

### DIFF
--- a/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
+++ b/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
@@ -838,7 +838,7 @@ class m230101_200000_FF4to5_MigrateData extends Migration
 
         $table = null;
         foreach ($tables as $databaseTable) {
-            if (preg_match("/{$prefix}(freeform_submissions_.*_{$formId}+)$/", $databaseTable->name)) {
+            if (preg_match("/{$prefix}(freeform_submissions_.*_{$formId})$/", $databaseTable->name)) {
                 $table = $databaseTable;
 
                 break;


### PR DESCRIPTION
Table name with `freeform_submissions_foobar_3` would be skipped if there was also a table named `freeform_submissions_foobar_33`

Fixes https://github.com/solspace/craft-freeform/issues/999#issuecomment-1980687695