### PR TITLE
Send nocache headers when rendering a CSRF input

### DIFF
--- a/packages/plugin/src/Bundles/Form/HiddenInputs/CsrfInput.php
+++ b/packages/plugin/src/Bundles/Form/HiddenInputs/CsrfInput.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Bundles\Form\HiddenInputs;
 
+use Craft;
 use Solspace\Freeform\Events\Forms\OutputAsJsonEvent;
 use Solspace\Freeform\Events\Forms\RenderTagEvent;
 use Solspace\Freeform\Form\Form;
@@ -16,6 +17,9 @@ class CsrfInput extends FeatureBundle
         if (!$isCsrfEnabled) {
             return;
         }
+
+        // Prevent response from being cached with token
+        Craft::$app->getResponse()->setNoCacheHeaders();
 
         Event::on(Form::class, Form::EVENT_RENDER_AFTER_OPEN_TAG, [$this, 'attachInput']);
         Event::on(Form::class, Form::EVENT_OUTPUT_AS_JSON, [$this, 'attachToJson']);


### PR DESCRIPTION
Hint to browsers and caching mechanisms that a cached response should not be used.
See https://github.com/solspace/craft-freeform/pull/1146