### PR TITLE
Table already exists error during migration

### DIFF
--- a/packages/plugin/src/migrations/m220330_111857_SplitSubmissionsTable.php
+++ b/packages/plugin/src/migrations/m220330_111857_SplitSubmissionsTable.php
@@ -5,6 +5,7 @@ namespace Solspace\Freeform\migrations;
 use craft\db\Migration;
 use craft\db\Query;
 use craft\helpers\StringHelper;
+use Solspace\Freeform\Library\Migrations\ForeignKey;
 
 class m220330_111857_SplitSubmissionsTable extends Migration
 {
@@ -81,7 +82,6 @@ class m220330_111857_SplitSubmissionsTable extends Migration
             }
 
             $tableName = $this->createFormTable($formId, $formHandle, $fieldMap);
-
             if ($tableName) {
                 $this->swapData($formId, $tableName, $fieldMap);
             }
@@ -115,6 +115,7 @@ class m220330_111857_SplitSubmissionsTable extends Migration
         $formHandle = trim($formHandle, '-_');
 
         $tableName = "{{%freeform_submissions_{$formHandle}_{$id}}}";
+
         $tableExists = \Craft::$app->db->schema->getTableSchema($tableName);
 
         if (is_null($tableExists)) {
@@ -124,7 +125,7 @@ class m220330_111857_SplitSubmissionsTable extends Migration
                 $this->addPrimaryKey('PK', $tableName, ['id']);
             }
 
-            $this->addForeignKey(null, $tableName, 'id', '{{%freeform_submissions}}', 'id', 'CASCADE');
+            $this->addForeignKey(null, $tableName, 'id', '{{%freeform_submissions}}', 'id', ForeignKey::CASCADE);
 
             return $tableName;
         }

--- a/packages/plugin/src/migrations/m220330_111857_SplitSubmissionsTable.php
+++ b/packages/plugin/src/migrations/m220330_111857_SplitSubmissionsTable.php
@@ -40,12 +40,14 @@ class m220330_111857_SplitSubmissionsTable extends Migration
         $forms = (new Query())
             ->select(['id', 'handle', 'layoutJson'])
             ->from('{{%freeform_forms}}')
-            ->all();
+            ->all()
+        ;
 
         $fields = (new Query())
             ->select(['id', 'handle'])
             ->from('{{%freeform_fields}}')
-            ->pairs();
+            ->pairs()
+        ;
 
         $prefix = \Craft::$app->db->tablePrefix;
         $prefixLength = \strlen($prefix);
@@ -78,7 +80,7 @@ class m220330_111857_SplitSubmissionsTable extends Migration
                 $handle = StringHelper::truncate($handle, 50, '');
                 $handle = trim($handle, '-_');
 
-                $fieldMap["field_{$id}"] = $handle . '_' . $id;
+                $fieldMap["field_{$id}"] = $handle.'_'.$id;
             }
 
             $tableName = $this->createFormTable($formId, $formHandle, $fieldMap);
@@ -118,7 +120,7 @@ class m220330_111857_SplitSubmissionsTable extends Migration
 
         $tableExists = \Craft::$app->db->schema->getTableSchema($tableName);
 
-        if (is_null($tableExists)) {
+        if (null === $tableExists) {
             $this->createTable($tableName, $tableColumns);
 
             if (!$this->db->getIsPgsql()) {
@@ -139,7 +141,8 @@ class m220330_111857_SplitSubmissionsTable extends Migration
             ->select(['id', ...array_keys($fieldMap)])
             ->from('{{%freeform_submissions}}')
             ->where(['formId' => $formId])
-            ->indexBy('id');
+            ->indexBy('id')
+        ;
 
         foreach ($submissionQuery->batch() as $batch) {
             $insertRows = [];


### PR DESCRIPTION
Fixes an issue when running an upgrade from C3 to C4 `(Database Exception: SQLSTATE[42S01]: Base table or view already exists: ).`

Checks if the table already exist otherwise creates the table based off `\Craft::$app->db->schema->getTableSchema($tableName);`

[See for ref](https://github.com/solspace/craft-freeform/issues/1111)