### PR TITLE
[SFT-1008]: The "Maximum Length" setting for Text fields

### DIFF
--- a/packages/plugin/src/Bundles/Fields/Implementations/MaxLength/MaxLengthBundle.php
+++ b/packages/plugin/src/Bundles/Fields/Implementations/MaxLength/MaxLengthBundle.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Solspace\Freeform\Bundles\Fields\Implementations\MaxLength;
+
+use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
+use Solspace\Freeform\Fields\FieldInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
+use Solspace\Freeform\Library\Bundles\FeatureBundle;
+use yii\base\Event;
+
+class MaxLengthBundle extends FeatureBundle
+{
+    public function __construct()
+    {
+        Event::on(
+            FieldInterface::class,
+            FieldInterface::EVENT_COMPILE_ATTRIBUTES,
+            [$this, 'updateContainerAttributes'],
+        );
+    }
+
+    public function updateContainerAttributes(CompileFieldAttributesEvent $event): void
+    {
+        $field = $event->getField();
+        if (!$field instanceof MaxLengthInterface) {
+            return;
+        }
+
+        if (!$field->getMaxLength()) {
+            return;
+        }
+
+        $event
+            ->getAttributes()
+            ->getInput()
+            ->setIfEmpty('maxlength', $field->getMaxLength())
+        ;
+    }
+}

--- a/packages/plugin/src/Bundles/Fields/Validation/MaxLengthValidation.php
+++ b/packages/plugin/src/Bundles/Fields/Validation/MaxLengthValidation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Solspace\Freeform\Bundles\Fields\Validation;
+
+use Solspace\Freeform\Events\Fields\ValidateEvent;
+use Solspace\Freeform\Fields\FieldInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
+use Solspace\Freeform\Freeform;
+use Solspace\Freeform\Library\Bundles\FeatureBundle;
+use yii\base\Event;
+
+class MaxLengthValidation extends FeatureBundle
+{
+    public function __construct()
+    {
+        Event::on(
+            FieldInterface::class,
+            FieldInterface::EVENT_VALIDATE,
+            [$this, 'validate']
+        );
+    }
+
+    public function validate(ValidateEvent $event): void
+    {
+        $field = $event->getField();
+        if (!$field instanceof MaxLengthInterface) {
+            return;
+        }
+
+        $maxLength = $field->getMaxLength();
+        if ($maxLength <= 0) {
+            return;
+        }
+
+        $value = $field->getValue();
+        if (\strlen($value) > $maxLength) {
+            $field->addError(
+                Freeform::t(
+                    'Value must be no more than {maxLength} characters',
+                    ['maxLength' => $maxLength]
+                )
+            );
+        }
+    }
+}

--- a/packages/plugin/src/Bundles/GraphQL/Types/Generators/FieldGenerator.php
+++ b/packages/plugin/src/Bundles/GraphQL/Types/Generators/FieldGenerator.php
@@ -582,6 +582,28 @@ class FieldGenerator extends AbstractGenerator
             ];
         }
 
+        $maxLengthTypes = [
+            FreeformFieldInterface::TYPE_TEXT,
+            FreeformFieldInterface::TYPE_TEXTAREA,
+            FreeformFieldInterface::TYPE_EMAIL,
+            FreeformFieldInterface::TYPE_CONFIRMATION,
+            FreeformFieldInterface::TYPE_DATETIME,
+            FreeformFieldInterface::TYPE_PHONE,
+            FreeformFieldInterface::TYPE_PASSWORD,
+            FreeformFieldInterface::TYPE_REGEX,
+            FreeformFieldInterface::TYPE_WEBSITE,
+            FreeformFieldInterface::TYPE_HIDDEN,
+            FreeformFieldInterface::TYPE_INVISIBLE,
+            FreeformFieldInterface::TYPE_NUMBER,
+        ];
+        if (\in_array($typeName, $maxLengthTypes, true)) {
+            $fieldDefinitions['maxLength'] = [
+                'name' => 'maxLength',
+                'type' => Type::int(),
+                'description' => 'The maximum length of characters for this field',
+            ];
+        }
+
         return $fieldDefinitions;
     }
 

--- a/packages/plugin/src/Fields/Implementations/EmailField.php
+++ b/packages/plugin/src/Fields/Implementations/EmailField.php
@@ -17,10 +17,12 @@ use Solspace\Freeform\Fields\AbstractField;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\EncryptionInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
 use Solspace\Freeform\Fields\Interfaces\PlaceholderInterface;
 use Solspace\Freeform\Fields\Interfaces\RecipientInterface;
 use Solspace\Freeform\Fields\Traits\DefaultTextValueTrait;
 use Solspace\Freeform\Fields\Traits\EncryptionTrait;
+use Solspace\Freeform\Fields\Traits\MaxLengthTrait;
 use Solspace\Freeform\Fields\Traits\PlaceholderTrait;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Notifications\Components\Recipients\Recipient;
@@ -32,10 +34,11 @@ use Solspace\Freeform\Notifications\Components\Recipients\RecipientCollection;
     iconPath: __DIR__.'/Icons/email.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/text.ejs',
 )]
-class EmailField extends AbstractField implements RecipientInterface, PlaceholderInterface, DefaultValueInterface, EncryptionInterface
+class EmailField extends AbstractField implements RecipientInterface, PlaceholderInterface, DefaultValueInterface, EncryptionInterface, MaxLengthInterface
 {
     use DefaultTextValueTrait;
     use EncryptionTrait;
+    use MaxLengthTrait;
     use PlaceholderTrait;
 
     /**

--- a/packages/plugin/src/Fields/Implementations/Pro/ConfirmationField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/ConfirmationField.php
@@ -11,11 +11,13 @@ use Solspace\Freeform\Fields\AbstractField;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\EncryptionInterface;
 use Solspace\Freeform\Fields\Interfaces\ExtraFieldInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
 use Solspace\Freeform\Fields\Interfaces\NoEmailPresenceInterface;
 use Solspace\Freeform\Fields\Interfaces\PlaceholderInterface;
 use Solspace\Freeform\Fields\Interfaces\RecipientInterface;
 use Solspace\Freeform\Fields\Interfaces\TextInterface;
 use Solspace\Freeform\Fields\Traits\EncryptionTrait;
+use Solspace\Freeform\Fields\Traits\MaxLengthTrait;
 use Solspace\Freeform\Fields\Traits\PlaceholderTrait;
 use Solspace\Freeform\Library\Exceptions\FreeformException;
 
@@ -25,9 +27,10 @@ use Solspace\Freeform\Library\Exceptions\FreeformException;
     iconPath: __DIR__.'/../Icons/confirm.svg',
     previewTemplatePath: __DIR__.'/../PreviewTemplates/confirmation.ejs',
 )]
-class ConfirmationField extends AbstractField implements ExtraFieldInterface, PlaceholderInterface, EncryptionInterface, NoEmailPresenceInterface
+class ConfirmationField extends AbstractField implements ExtraFieldInterface, PlaceholderInterface, EncryptionInterface, NoEmailPresenceInterface, MaxLengthInterface
 {
     use EncryptionTrait;
+    use MaxLengthTrait;
     use PlaceholderTrait;
 
     #[ValueTransformer(FieldTransformer::class)]

--- a/packages/plugin/src/Fields/Implementations/Pro/DatetimeField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/DatetimeField.php
@@ -14,8 +14,10 @@ use Solspace\Freeform\Fields\AbstractField;
 use Solspace\Freeform\Fields\Interfaces\DatetimeInterface;
 use Solspace\Freeform\Fields\Interfaces\EncryptionInterface;
 use Solspace\Freeform\Fields\Interfaces\ExtraFieldInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
 use Solspace\Freeform\Fields\Interfaces\PlaceholderInterface;
 use Solspace\Freeform\Fields\Traits\EncryptionTrait;
+use Solspace\Freeform\Fields\Traits\MaxLengthTrait;
 
 #[Type(
     name: 'Date & Time',
@@ -23,9 +25,10 @@ use Solspace\Freeform\Fields\Traits\EncryptionTrait;
     iconPath: __DIR__.'/../Icons/date-time.svg',
     previewTemplatePath: __DIR__.'/../PreviewTemplates/date-time.ejs',
 )]
-class DatetimeField extends AbstractField implements PlaceholderInterface, DatetimeInterface, ExtraFieldInterface, EncryptionInterface
+class DatetimeField extends AbstractField implements PlaceholderInterface, DatetimeInterface, ExtraFieldInterface, EncryptionInterface, MaxLengthInterface
 {
     use EncryptionTrait;
+    use MaxLengthTrait;
 
     public const DATETIME_TYPE_BOTH = 'both';
     public const DATETIME_TYPE_DATE = 'date';

--- a/packages/plugin/src/Fields/Implementations/TextField.php
+++ b/packages/plugin/src/Fields/Implementations/TextField.php
@@ -17,10 +17,12 @@ use Solspace\Freeform\Attributes\Field\Type;
 use Solspace\Freeform\Fields\AbstractField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\EncryptionInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
 use Solspace\Freeform\Fields\Interfaces\PlaceholderInterface;
 use Solspace\Freeform\Fields\Interfaces\TextInterface;
 use Solspace\Freeform\Fields\Traits\DefaultTextValueTrait;
 use Solspace\Freeform\Fields\Traits\EncryptionTrait;
+use Solspace\Freeform\Fields\Traits\MaxLengthTrait;
 use Solspace\Freeform\Fields\Traits\PlaceholderTrait;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
@@ -33,10 +35,11 @@ use Symfony\Component\Serializer\Annotation\Ignore;
     iconPath: __DIR__.'/Icons/text.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/text.ejs',
 )]
-class TextField extends AbstractField implements PlaceholderInterface, DefaultValueInterface, TextInterface, EncryptionInterface
+class TextField extends AbstractField implements PlaceholderInterface, DefaultValueInterface, TextInterface, EncryptionInterface, MaxLengthInterface
 {
     use DefaultTextValueTrait;
     use EncryptionTrait;
+    use MaxLengthTrait;
     use PlaceholderTrait;
 
     #[Ignore]

--- a/packages/plugin/src/Fields/Implementations/TextareaField.php
+++ b/packages/plugin/src/Fields/Implementations/TextareaField.php
@@ -18,9 +18,11 @@ use Solspace\Freeform\Attributes\Property\Input;
 use Solspace\Freeform\Fields\AbstractField;
 use Solspace\Freeform\Fields\Interfaces\DefaultValueInterface;
 use Solspace\Freeform\Fields\Interfaces\EncryptionInterface;
+use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
 use Solspace\Freeform\Fields\Interfaces\PlaceholderInterface;
 use Solspace\Freeform\Fields\Traits\DefaultTextValueTrait;
 use Solspace\Freeform\Fields\Traits\EncryptionTrait;
+use Solspace\Freeform\Fields\Traits\MaxLengthTrait;
 use Solspace\Freeform\Fields\Traits\PlaceholderTrait;
 
 #[Type(
@@ -29,10 +31,11 @@ use Solspace\Freeform\Fields\Traits\PlaceholderTrait;
     iconPath: __DIR__.'/Icons/textarea.svg',
     previewTemplatePath: __DIR__.'/PreviewTemplates/textarea.ejs',
 )]
-class TextareaField extends AbstractField implements PlaceholderInterface, DefaultValueInterface, EncryptionInterface
+class TextareaField extends AbstractField implements PlaceholderInterface, DefaultValueInterface, EncryptionInterface, MaxLengthInterface
 {
     use DefaultTextValueTrait;
     use EncryptionTrait;
+    use MaxLengthTrait;
     use PlaceholderTrait;
 
     #[Input\TextArea(

--- a/packages/plugin/src/Fields/Interfaces/MaxLengthInterface.php
+++ b/packages/plugin/src/Fields/Interfaces/MaxLengthInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Freeform for Craft CMS.
+ *
+ * @author        Solspace, Inc.
+ * @copyright     Copyright (c) 2008-2024, Solspace, Inc.
+ *
+ * @see           https://docs.solspace.com/craft/freeform
+ *
+ * @license       https://docs.solspace.com/license-agreement
+ */
+
+namespace Solspace\Freeform\Fields\Interfaces;
+
+interface MaxLengthInterface
+{
+    public function getMaxLength(): ?int;
+}

--- a/packages/plugin/src/Fields/Traits/MaxLengthTrait.php
+++ b/packages/plugin/src/Fields/Traits/MaxLengthTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Solspace\Freeform\Fields\Traits;
+
+use Solspace\Freeform\Attributes\Property\Input;
+
+trait MaxLengthTrait
+{
+    #[Input\Integer(
+        instructions: 'The maximum number of characters allowed in the field.',
+        order: 50,
+    )]
+    protected ?int $maxLength = null;
+
+    public function getMaxLength(): ?int
+    {
+        return $this->maxLength;
+    }
+}


### PR DESCRIPTION
### Related Ticket Number

SFT-1008

### Description

Some text fields need to have a maximum length specified.

- adding `max length` property to specific fields

### Images

<!-- optional -->
