### PR TITLE
fix(SFT-1035): Prevent Notification Persistence throwing errors if the form upsert event has errors.

### DIFF
--- a/packages/plugin/src/Bundles/Persistence/NotificationPersistence.php
+++ b/packages/plugin/src/Bundles/Persistence/NotificationPersistence.php
@@ -27,6 +27,10 @@ class NotificationPersistence extends FeatureBundle
 
     public function handleNotificationSave(PersistFormEvent $event): void
     {
+        if ($event->hasErrors()) {
+            return;
+        }
+
         $notifications = $event->getPayload()->notifications ?? null;
         if (null === $notifications) {
             return;
@@ -71,10 +75,6 @@ class NotificationPersistence extends FeatureBundle
                 ->delete(FormNotificationRecord::TABLE, ['uid' => $deletableUIDs])
                 ->execute()
             ;
-        }
-
-        if ($event->hasErrors()) {
-            return;
         }
 
         foreach ($records as $record) {


### PR DESCRIPTION
Related to https://github.com/solspace/craft-freeform/discussions/1239

Also read last few comments in https://solspace.atlassian.net/browse/SFT-1035

I feel there is still an issue, as the user should be getting error icon and message in the layout tab if the form has errors. 