### PR TITLE
fix(SFT-1081): Set integration model properties after EVENT_BEFORE_SAVE

### DIFF
--- a/packages/plugin/src/Services/Integrations/IntegrationsService.php
+++ b/packages/plugin/src/Services/Integrations/IntegrationsService.php
@@ -173,14 +173,14 @@ class IntegrationsService extends BaseService
             $model->addError('integration', $e->getMessage());
         }
 
-        $this->updateModelFromIntegration($model, $integration);
-
         $isNew = !$model->id;
 
         $beforeSaveEvent = new SaveEvent($model, $integration, $isNew);
         if ($triggerEvents) {
             $this->trigger(self::EVENT_BEFORE_SAVE, $beforeSaveEvent);
         }
+
+        $this->updateModelFromIntegration($model, $integration);
 
         if ($isNew) {
             $record = new IntegrationRecord();


### PR DESCRIPTION
Sets Model data after `EVENT_BEFORE_SAVE` to give any event listeners a chance to set values first.

Resolves https://solspace.atlassian.net/browse/SFT-1081