### PR TITLE
[#1253]: Export profiles breaking on destructuring recipients

### DIFF
--- a/packages/plugin/src/Bundles/Notifications/Export/ExportNotifications.php
+++ b/packages/plugin/src/Bundles/Notifications/Export/ExportNotifications.php
@@ -10,6 +10,7 @@ use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use Solspace\Freeform\Library\DataObjects\NotificationTemplate;
 use Solspace\Freeform\Library\Exceptions\FreeformException;
 use Solspace\Freeform\Library\Helpers\EncryptionHelper;
+use Solspace\Freeform\Notifications\Components\Recipients\RecipientCollection;
 use Solspace\Freeform\Records\NotificationLogRecord;
 use Solspace\Freeform\Records\NotificationTemplateRecord;
 use Solspace\Freeform\Records\Pro\ExportNotificationRecord;
@@ -83,9 +84,10 @@ class ExportNotifications extends FeatureBundle
             $record->bodyText = $message;
 
             $template = NotificationTemplate::fromRecord($record);
+            $recipients = RecipientCollection::fromArray(json_decode($notification->recipients));
 
             $message = $mailer->compileMessage($template, $variables);
-            $message->setTo($mailer->processRecipients(json_decode($notification->recipients)));
+            $message->setTo($mailer->processRecipients($recipients));
 
             $data = $profile->getSubmissionData();
 


### PR DESCRIPTION
### Related Ticket Number

#1253

### Description

When setting up export notifications and specifying multiple emails, the notification crashes when building the message, because it expects an instance of `RecipientCollection`

- building a `RecipientCollection` from the reipient email array and then passing it to the message.
