### PR TITLE
[#1224]: Improving twig template debugging for formatting templates

### DIFF
--- a/packages/plugin/src/Services/FilesService.php
+++ b/packages/plugin/src/Services/FilesService.php
@@ -546,12 +546,7 @@ class FilesService extends BaseService implements FileUploadHandlerInterface
             $folder = $rootFolder;
         } else {
             try {
-                $renderedSubpath = \Craft::$app->view->renderString(
-                    $subpath,
-                    [
-                        'form' => $form,
-                    ]
-                );
+                $renderedSubpath = \Craft::$app->view->renderString($subpath, ['form' => $form]);
             } catch (Throwable $e) {
                 throw new InvalidSubpathException($subpath, null, 0, $e);
             }

--- a/packages/plugin/src/Services/FormsService.php
+++ b/packages/plugin/src/Services/FormsService.php
@@ -318,6 +318,7 @@ class FormsService extends BaseService implements FormHandlerInterface
         foreach ($customTemplates as $template) {
             if (str_ends_with($template->getFilePath(), $templateName)) {
                 $templatePath = $template->getFilePath();
+                $templatePath = str_replace(\Craft::getAlias('@templates/'), '', $templatePath);
 
                 break;
             }
@@ -327,6 +328,8 @@ class FormsService extends BaseService implements FormHandlerInterface
             foreach ($solspaceTemplates as $template) {
                 if (str_ends_with($template->getFilePath(), $templateName)) {
                     $templatePath = $template->getFilePath();
+                    $templatePath = str_replace(\Craft::getAlias('@freeform/templates/'), '', $templatePath);
+                    $templatePath = 'freeform/'.$templatePath;
                     $templateMode = View::TEMPLATE_MODE_CP;
 
                     break;
@@ -334,7 +337,7 @@ class FormsService extends BaseService implements FormHandlerInterface
             }
         }
 
-        if (null === $templatePath || !file_exists($templatePath)) {
+        if (null === $templatePath) {
             throw new FreeformException(
                 Freeform::t(
                     "Form template '{name}' not found",
@@ -343,8 +346,8 @@ class FormsService extends BaseService implements FormHandlerInterface
             );
         }
 
-        $output = \Craft::$app->view->renderString(
-            file_get_contents($templatePath),
+        $output = \Craft::$app->view->renderTemplate(
+            $templatePath,
             [
                 'form' => $form,
                 'formCss' => $this->getFormattingTemplateCss($templateName),
@@ -369,12 +372,13 @@ class FormsService extends BaseService implements FormHandlerInterface
         foreach ($templates as $template) {
             if ($template->getFileName() === $templateName) {
                 $templatePath = $template->getFilePath();
+                $templatePath = str_replace(\Craft::getAlias('@templates/'), '', $templatePath);
 
                 break;
             }
         }
 
-        if (null === $templatePath || !file_exists($templatePath)) {
+        if (null === $templatePath) {
             throw new FreeformException(
                 Freeform::t(
                     "Success template '{name}' not found",
@@ -383,8 +387,8 @@ class FormsService extends BaseService implements FormHandlerInterface
             );
         }
 
-        $output = \Craft::$app->view->renderString(
-            file_get_contents($templatePath),
+        $output = \Craft::$app->view->renderTemplate(
+            $templatePath,
             ['form' => $form]
         );
 


### PR DESCRIPTION
### Related Ticket Number

#1224

### Description

When an error is encountered during the rendering of a Freeform Form formatting template, a cryptic error message was thrown, without displaying the template file's line and surrounding code. Instead a single string of a compiled template is shown. This was due to the use of `::renderString` method, rather than `::renderTwig` method.

- switching from `::renderString` to `::renderTemplate` when rendering formatting templates