### PR TITLE
fix(SFT-1090): Run form limits after the form has rendered

### DIFF
--- a/packages/plugin/src/Bundles/Form/Limiting/FormLimiting.php
+++ b/packages/plugin/src/Bundles/Form/Limiting/FormLimiting.php
@@ -33,7 +33,7 @@ class FormLimiting extends FeatureBundle
 
     public function __construct()
     {
-        Event::on(Form::class, Form::EVENT_FORM_LOADED, [$this, 'handleDuplicateCheck']);
+        Event::on(Form::class, Form::EVENT_RENDER_AFTER_CLOSING_TAG, [$this, 'handleDuplicateCheck']);
         Event::on(Form::class, Form::EVENT_PERSIST_STATE, [$this, 'handleDuplicateCheck']);
         Event::on(Form::class, Form::EVENT_BEFORE_VALIDATE, [$this, 'handleDuplicateCheck']);
     }


### PR DESCRIPTION
### Related Ticket

[SFT-1090](https://solspace.atlassian.net/browse/SFT-1090)

### Fixes

https://github.com/solspace/craft-freeform/issues/1125

[SFT-1090]: https://solspace.atlassian.net/browse/SFT-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ