### PR TITLE
fix(SFT-1094): Make sure Origins is in the expected format (FF5)

### DIFF
--- a/packages/plugin/src/controllers/SubmitController.php
+++ b/packages/plugin/src/controllers/SubmitController.php
@@ -131,7 +131,7 @@ class SubmitController extends BaseController
             ],
             'Access-Control-Allow-Credentials' => !\is_array($origins) || !\in_array('*', $origins, true),
             'Access-Control-Max-Age' => 86400,
-            'Origin' => $origins,
+            'Origin' => \is_array($origins) ? $origins : [$origins],
         ];
 
         $event = new ConfigureCORSEvent($corsHeaders);


### PR DESCRIPTION
### Related Ticket Number

https://github.com/solspace/craft-freeform/issues/1247

### Description

When setting `allowedGraphqlOrigins` to `false`, the form submissions crashed.
Origin expects an array, so wrap any values in an array if not an array.