### PR TITLE
[SFT-1138]: Express Forms migration utility crash

### DIFF
--- a/packages/plugin/src/Bundles/Backup/Export/ExpressFormsExporter.php
+++ b/packages/plugin/src/Bundles/Backup/Export/ExpressFormsExporter.php
@@ -39,6 +39,7 @@ use Solspace\Freeform\Fields\Implementations\TextareaField;
 use Solspace\Freeform\Fields\Implementations\TextField;
 use Solspace\Freeform\Form\Settings\Implementations\ValueGenerators\RandomColorGenerator;
 use Solspace\Freeform\Form\Settings\Settings as FormSettings;
+use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\DataObjects\Form\Defaults\Defaults;
 use Solspace\Freeform\Library\Helpers\JsonHelper;
 use Solspace\Freeform\Library\Helpers\StringHelper as FreeformStringHelper;
@@ -98,6 +99,7 @@ class ExpressFormsExporter implements ExporterInterface
 
     private function collectForms(?array $ids = null): FormCollection
     {
+        $colorGenerator = new RandomColorGenerator();
         $collection = new FormCollection();
 
         $forms = (new Query())
@@ -107,15 +109,7 @@ class ExpressFormsExporter implements ExporterInterface
             ->all()
         ;
 
-        $defaultStatus = (int) (new Query())
-            ->select('id')
-            ->from('{{%freeform_statuses}}')
-            ->where(['isDefault' => true])
-            ->limit(1)
-            ->scalar()
-        ;
-
-        $colorGenerator = new RandomColorGenerator();
+        $defaultStatus = Freeform::getInstance()->statuses->getDefaultStatusId();
 
         foreach ($forms as $index => $form) {
             $exported = new Form();


### PR DESCRIPTION
### Related Ticket Number
[SFT-1138](https://solspace.atlassian.net/browse/SFT-1138)

### Description
When opening the **Express Forms Migration** utility page, it crashes due to the lookup of the default form status by `isDefault` column, which is gone since **Freeform** *v5.1.19+*

- updating the lookup to use the *status service* instead of manually looking up the database column


[SFT-1138]: https://solspace.atlassian.net/browse/SFT-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ