### PR TITLE
[SFT-1139]: Fetching payment records in Submissions query no longer possible since v5

### DIFF
--- a/packages/plugin/src/Integrations/PaymentGateways/Common/PaymentFieldInterface.php
+++ b/packages/plugin/src/Integrations/PaymentGateways/Common/PaymentFieldInterface.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Integrations\PaymentGateways\Common;
 
+use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\NoEmailPresenceInterface;
 
-interface PaymentFieldInterface extends NoEmailPresenceInterface {}
+interface PaymentFieldInterface extends NoEmailPresenceInterface, FieldInterface {}

--- a/packages/plugin/src/Integrations/PaymentGateways/Stripe/EventListeners/RenderNotifications.php
+++ b/packages/plugin/src/Integrations/PaymentGateways/Stripe/EventListeners/RenderNotifications.php
@@ -4,14 +4,14 @@ namespace Solspace\Freeform\Integrations\PaymentGateways\Stripe\EventListeners;
 
 use Solspace\Freeform\Events\Mailer\RenderEmailEvent;
 use Solspace\Freeform\Integrations\PaymentGateways\Stripe\Fields\StripeField;
+use Solspace\Freeform\Integrations\PaymentGateways\Stripe\Services\StripePaymentService;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use Solspace\Freeform\Services\MailerService;
-use Stripe\PaymentIntent;
 use yii\base\Event;
 
 class RenderNotifications extends FeatureBundle
 {
-    public function __construct()
+    public function __construct(private StripePaymentService $paymentService)
     {
         Event::on(
             MailerService::class,
@@ -23,7 +23,6 @@ class RenderNotifications extends FeatureBundle
     public function prepareTemplateValues(RenderEmailEvent $event): void
     {
         $form = $event->getForm();
-        $submission = $event->getSubmission();
 
         $fields = $form->getLayout()->getFields(StripeField::class);
         if (!$fields->count()) {
@@ -50,7 +49,7 @@ class RenderNotifications extends FeatureBundle
             ;
 
             if ($intent) {
-                $payments[$field->getHandle()] = $this->intentToModel($field, $intent);
+                $payments[$field->getHandle()] = $this->paymentService->intentToModel($field, $intent);
             }
         }
 
@@ -59,20 +58,5 @@ class RenderNotifications extends FeatureBundle
         }
 
         $event->add('payments', $payments);
-    }
-
-    private function intentToModel(StripeField $field, PaymentIntent $intent): array
-    {
-        return [
-            'amount' => $intent->amount / 100,
-            'currency' => strtoupper($intent->currency),
-            'status' => $intent->status,
-            'errorMessage' => $intent->last_payment_error ? $intent->last_payment_error->message : '',
-            'card' => $intent->payment_method?->card?->last4,
-            'type' => $field->getPaymentType(),
-            'planName' => $intent->invoice?->subscription?->plan?->product?->name ?? '',
-            'interval' => $intent->invoice?->subscription?->plan?->interval ?? '',
-            'frequency' => $intent->invoice?->subscription?->plan?->frequency ?? '',
-        ];
     }
 }

--- a/packages/plugin/src/Integrations/PaymentGateways/Stripe/Services/StripeCallbackService.php
+++ b/packages/plugin/src/Integrations/PaymentGateways/Stripe/Services/StripeCallbackService.php
@@ -42,7 +42,7 @@ class StripeCallbackService
 
             $paymentIntent = $stripe->paymentIntents->retrieve(
                 $paymentIntent->id,
-                ['expand' => ['customer', 'payment_method', 'invoice.subscription']]
+                ['expand' => ['customer', 'payment_method', 'invoice.subscription.plan.product']]
             );
 
             $form->quickLoad($payload);
@@ -86,6 +86,13 @@ class StripeCallbackService
         if ($paymentMethod) {
             $metadata['type'] = $paymentMethod->type;
             $metadata['details'] = $paymentMethod->{$paymentMethod->type}->toArray();
+        }
+
+        $planName = $paymentIntent?->invoice?->subscription?->plan?->product?->name ?? null;
+        if ($planName) {
+            $metadata['planName'] = $planName;
+            $metadata['interval'] = $paymentIntent?->invoice?->subscription?->plan?->interval ?? null;
+            $metadata['frequency'] = $paymentIntent?->invoice?->subscription?->plan?->interval_count ?? null;
         }
 
         $payment->metadata = $metadata;

--- a/packages/plugin/src/Integrations/PaymentGateways/Stripe/Services/StripePaymentService.php
+++ b/packages/plugin/src/Integrations/PaymentGateways/Stripe/Services/StripePaymentService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Solspace\Freeform\Integrations\PaymentGateways\Stripe\Services;
+
+use Solspace\Freeform\Integrations\PaymentGateways\Stripe\Fields\StripeField;
+use Solspace\Freeform\Models\Payments\PaymentModel;
+use Solspace\Freeform\Records\Pro\Payments\PaymentRecord;
+use Stripe\PaymentIntent;
+
+class StripePaymentService
+{
+    public function recordToModel(PaymentRecord $record): ?PaymentModel
+    {
+        $method = $record->getPaymentMethod();
+
+        if (!$method || !$method->details) {
+            return null;
+        }
+
+        $details = $method->details;
+
+        $model = new PaymentModel();
+        $model->amount = $record->amount / 100;
+        $model->currency = strtoupper($record->currency);
+        $model->status = $record->status;
+        $model->card = $details->last4 ?? null;
+        $model->brand = $details->brand ?? null;
+        $model->type = $record->type;
+        $model->planName = $method->planName ?? null;
+        $model->interval = $method->interval ?? null;
+        $model->frequency = $method->frequency ?? null;
+        $model->errorMessage = $method->error ?? null;
+
+        return $model;
+    }
+
+    public function intentToModel(StripeField $field, PaymentIntent $intent): PaymentModel
+    {
+        $model = new PaymentModel();
+        $model->amount = $intent->amount / 100;
+        $model->currency = strtoupper($intent->currency);
+        $model->status = $intent->status;
+        $model->card = $intent->payment_method?->card?->last4 ?? null;
+        $model->brand = $intent->payment_method?->card?->brand ?? null;
+        $model->type = $field->getPaymentType();
+        $model->planName = $intent->invoice?->subscription?->plan?->product?->name ?? null;
+        $model->interval = $intent->invoice?->subscription?->plan?->interval ?? null;
+        $model->frequency = $intent->invoice?->subscription?->plan?->interval_count ?? null;
+
+        return $model;
+    }
+}

--- a/packages/plugin/src/Models/Payments/PaymentModel.php
+++ b/packages/plugin/src/Models/Payments/PaymentModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Solspace\Freeform\Models\Payments;
+
+use craft\base\Model;
+
+class PaymentModel extends Model
+{
+    public int $amount = 0;
+    public string $currency = '';
+    public string $status = '';
+    public ?string $errorMessage = null;
+    public ?string $card = null;
+    public ?string $brand = null;
+    public string $type = '';
+    public ?string $planName = null;
+    public ?string $interval = null;
+    public ?string $frequency = null;
+}


### PR DESCRIPTION
### Related Ticket Number
[SFT-1139](https://solspace.atlassian.net/browse/SFT-1139)
#1290

### Description
During the rework of all codebase in **Freeform 5**, the `craft.freeform.payments` template function was dropped and not reinstated. It has been brought back now.

- fixes


[SFT-1139]: https://solspace.atlassian.net/browse/SFT-1139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ