### PR TITLE
[SFT-1144][#1277][#1297]: Fixes for Table field overrides, sample formatting templates

### DIFF
--- a/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
+++ b/packages/plugin/src/Bundles/Fields/FieldContainerBundle.php
@@ -4,6 +4,7 @@ namespace Solspace\Freeform\Bundles\Fields;
 
 use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
 
@@ -20,6 +21,10 @@ class FieldContainerBundle extends FeatureBundle
 
     public function updateContainerAttributes(CompileFieldAttributesEvent $event): void
     {
+        if (FieldAttributesCollection::class !== $event->getClass()) {
+            return;
+        }
+
         $request = \Craft::$app->request;
         if ($request && $request->isCpRequest) {
             $isFreeform = 'freeform' === $request->getSegment(1);

--- a/packages/plugin/src/Bundles/Fields/Implementations/MaxLength/MaxLengthBundle.php
+++ b/packages/plugin/src/Bundles/Fields/Implementations/MaxLength/MaxLengthBundle.php
@@ -5,6 +5,7 @@ namespace Solspace\Freeform\Bundles\Fields\Implementations\MaxLength;
 use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\MaxLengthInterface;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
 
@@ -21,6 +22,10 @@ class MaxLengthBundle extends FeatureBundle
 
     public function updateContainerAttributes(CompileFieldAttributesEvent $event): void
     {
+        if (FieldAttributesCollection::class !== $event->getClass()) {
+            return;
+        }
+
         $field = $event->getField();
         if (!$field instanceof MaxLengthInterface) {
             return;

--- a/packages/plugin/src/Bundles/Fields/Implementations/MinLength/MinLengthBundle.php
+++ b/packages/plugin/src/Bundles/Fields/Implementations/MinLength/MinLengthBundle.php
@@ -5,6 +5,7 @@ namespace Solspace\Freeform\Bundles\Fields\Implementations\MinLength;
 use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\MinLengthInterface;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
 
@@ -21,6 +22,10 @@ class MinLengthBundle extends FeatureBundle
 
     public function updateContainerAttributes(CompileFieldAttributesEvent $event): void
     {
+        if (FieldAttributesCollection::class !== $event->getClass()) {
+            return;
+        }
+
         $field = $event->getField();
         if (!$field instanceof MinLengthInterface) {
             return;

--- a/packages/plugin/src/Bundles/Rules/RulesInitialState.php
+++ b/packages/plugin/src/Bundles/Rules/RulesInitialState.php
@@ -7,6 +7,7 @@ use Solspace\Freeform\Events\Fields\CompileFieldAttributesEvent;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Form\Layout\Page\Buttons\PageButtons;
 use Solspace\Freeform\Library\Attributes\Attributes;
+use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use yii\base\Event;
 
@@ -35,6 +36,10 @@ class RulesInitialState extends FeatureBundle
 
     public function setInitialState(CompileFieldAttributesEvent $event): void
     {
+        if (FieldAttributesCollection::class !== $event->getClass()) {
+            return;
+        }
+
         $field = $event->getField();
         $form = $field->getForm();
 

--- a/packages/plugin/src/Events/Fields/CompileFieldAttributesEvent.php
+++ b/packages/plugin/src/Events/Fields/CompileFieldAttributesEvent.php
@@ -3,14 +3,22 @@
 namespace Solspace\Freeform\Events\Fields;
 
 use Solspace\Freeform\Fields\FieldInterface;
-use Solspace\Freeform\Library\Attributes\FieldAttributesCollection;
+use Solspace\Freeform\Library\Attributes\Attributes;
 use yii\base\Event;
 
+/**
+ * @template T of Attributes
+ */
 class CompileFieldAttributesEvent extends Event
 {
+    /**
+     * @param T               $attributes
+     * @param class-string<T> $class
+     */
     public function __construct(
         private FieldInterface $field,
-        private FieldAttributesCollection $attributes,
+        private Attributes $attributes,
+        private string $class,
     ) {
         parent::__construct();
     }
@@ -20,15 +28,29 @@ class CompileFieldAttributesEvent extends Event
         return $this->field;
     }
 
-    public function getAttributes(): FieldAttributesCollection
+    /**
+     * @return T
+     */
+    public function getAttributes(): Attributes
     {
         return $this->attributes;
     }
 
-    public function setAttributes(FieldAttributesCollection $attributes): self
+    /**
+     * @param T $attributes
+     */
+    public function setAttributes(Attributes $attributes): self
     {
         $this->attributes = $attributes;
 
         return $this;
+    }
+
+    /**
+     * @return class-string<T>
+     */
+    public function getClass(): string
+    {
+        return $this->class;
     }
 }

--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -415,7 +415,12 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
 
     public function getAttributes(): FieldAttributesCollection
     {
-        $event = new CompileFieldAttributesEvent($this, $this->attributes->clone());
+        $event = new CompileFieldAttributesEvent(
+            $this,
+            $this->attributes->clone(),
+            FieldAttributesCollection::class
+        );
+
         Event::trigger($this, self::EVENT_COMPILE_ATTRIBUTES, $event);
 
         return $event->getAttributes();

--- a/packages/plugin/src/templates/_templates/formatting/basic-dark/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/basic-dark/_main.css
@@ -1,8 +1,6 @@
 /* LAYOUT */
-html, body {
+.freeform-form {
     font-family: sans-serif;
-}
-* {
     box-sizing: border-box;
 }
 .freeform-row::after {
@@ -16,7 +14,10 @@ html, body {
 }
 
 /* BUTTONS */
-button {
+.freeform-form [data-freeform-controls] {
+    margin-top: 15px;
+}
+.freeform-form button {
     font: 400 18px sans-serif;
     line-height: 1.5;
     color: #ffffff;
@@ -26,39 +27,38 @@ button {
     border-radius: 5px;
     background-color: #0d6efd;
     padding: 5px 15px;
-    margin-right: 10px;
+    margin: 0 10px !important;
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
     transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out;
     justify-content: center;
 }
-button:only-child,
-button:last-child {
+.freeform-form button:only-child,
+.freeform-form button:last-child {
     margin-right: 0;
 }
-button:hover {
+.freeform-form button:hover {
     color: #ffffff;
     background-color: #0b5ed7;
     border-color: #0a58ca;
 }
-button[data-freeform-action="back"] {
-    font: 400 18px sans-serif;
+.freeform-form button[data-freeform-action="back"] {
     color: #6c757d;
     background-color: transparent;
     border-color: #6c757d;
 }
-button[data-freeform-action="back"]:hover {
+.freeform-form button[data-freeform-action="back"]:hover {
     color: #ffffff;
     background-color: #6c757d;
     border-color: #6c757d;
 }
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -71,7 +71,7 @@ button[type=submit].freeform-processing:before {
     border-radius: 50%;
     animation: freeform-processing .5s linear infinite;
 }
-button:disabled {
+.freeform-form button:disabled {
     color: #ffffff;
     background-color: #5082cc;
     border-color: #497bc5;
@@ -243,7 +243,6 @@ button:disabled {
     padding: 0;
     list-style: none;
     display: block;
-    width: 100%;
 }
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-radios .freeform-errors,
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-checkboxes .freeform-errors {
@@ -441,7 +440,6 @@ button:disabled {
     margin-right: auto;
     margin-bottom: 20px;
     padding: 15px 20px;
-    width: 100%;
     border-radius: 5px;
 }
 .freeform-form-success p,

--- a/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/basic-dark/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/basic-floating-labels/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/basic-floating-labels/_main.css
@@ -1,8 +1,6 @@
 /* LAYOUT */
-html, body {
+.freeform-form {
     font-family: sans-serif;
-}
-* {
     box-sizing: border-box;
 }
 .freeform-row::after {
@@ -16,7 +14,10 @@ html, body {
 }
 
 /* BUTTONS */
-button {
+.freeform-form [data-freeform-controls] {
+    margin-top: 15px;
+}
+.freeform-form button {
     font: 400 18px sans-serif;
     line-height: 1.5;
     color: #ffffff;
@@ -26,52 +27,50 @@ button {
     border-radius: 5px;
     background-color: #0d6efd;
     padding: 5px 15px;
-    margin-right: 10px;
+    margin: 0 10px !important;
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
     transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out;
     justify-content: center;
 }
-button:only-child,
-button:last-child {
+.freeform-form button:only-child,
+.freeform-form button:last-child {
     margin-right: 0;
 }
-button:hover {
+.freeform-form button:hover {
     color: #ffffff;
     background-color: #0b5ed7;
     border-color: #0a58ca;
 }
-button[data-freeform-action="back"] {
-    font: 400 18px sans-serif;
+.freeform-form button[data-freeform-action="back"] {
     color: #6c757d;
     background-color: transparent;
     border-color: #6c757d;
 }
-button[data-freeform-action="back"]:hover {
+.freeform-form button[data-freeform-action="back"]:hover {
     color: #ffffff;
     background-color: #6c757d;
     border-color: #6c757d;
 }
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
     width: 11px;
     height: 11px;
-    margin-right: 10px;
     border-style: solid;
     border-width: 2px;
     border-color: transparent transparent #fff #fff;
     border-radius: 50%;
     animation: freeform-processing .5s linear infinite;
 }
-button:disabled {
+.freeform-form button:disabled {
     color: #ffffff;
     background-color: #5082cc;
     border-color: #497bc5;
@@ -327,7 +326,6 @@ button:disabled {
     padding: 0;
     list-style: none;
     display: block;
-    width: 100%;
 }
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-radios .freeform-errors,
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-checkboxes .freeform-errors {
@@ -546,7 +544,6 @@ button:disabled {
     margin-right: auto;
     margin-bottom: 20px;
     padding: 15px 20px;
-    width: 100%;
     border-radius: 5px;
 }
 .freeform-form-success p,

--- a/packages/plugin/src/templates/_templates/formatting/basic-floating-labels/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/basic-floating-labels/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/basic-light/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/basic-light/_main.css
@@ -1,8 +1,6 @@
 /* LAYOUT */
-html, body {
+.freeform-form {
     font-family: sans-serif;
-}
-* {
     box-sizing: border-box;
 }
 .freeform-row::after {
@@ -16,7 +14,10 @@ html, body {
 }
 
 /* BUTTONS */
-button {
+.freeform-form [data-freeform-controls] {
+    margin-top: 15px;
+}
+.freeform-form button {
     font: 400 18px sans-serif;
     line-height: 1.5;
     color: #ffffff;
@@ -26,39 +27,38 @@ button {
     border-radius: 5px;
     background-color: #0d6efd;
     padding: 5px 15px;
-    margin-right: 10px;
+    margin: 0 10px !important;
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
     transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out;
     justify-content: center;
 }
-button:only-child,
-button:last-child {
+.freeform-form button:only-child,
+.freeform-form button:last-child {
     margin-right: 0;
 }
-button:hover {
+.freeform-form button:hover {
     color: #ffffff;
     background-color: #0b5ed7;
     border-color: #0a58ca;
 }
-button[data-freeform-action="back"] {
-    font: 400 18px sans-serif;
+.freeform-form button[data-freeform-action="back"] {
     color: #6c757d;
     background-color: transparent;
     border-color: #6c757d;
 }
-button[data-freeform-action="back"]:hover {
+.freeform-form button[data-freeform-action="back"]:hover {
     color: #ffffff;
     background-color: #6c757d;
     border-color: #6c757d;
 }
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -71,7 +71,7 @@ button[type=submit].freeform-processing:before {
     border-radius: 50%;
     animation: freeform-processing .5s linear infinite;
 }
-button:disabled {
+.freeform-form button:disabled {
     color: #ffffff;
     background-color: #5082cc;
     border-color: #497bc5;
@@ -243,7 +243,6 @@ button:disabled {
     padding: 0;
     list-style: none;
     display: block;
-    width: 100%;
 }
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-radios .freeform-errors,
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-checkboxes .freeform-errors {
@@ -442,7 +441,6 @@ button:disabled {
     margin-right: auto;
     margin-bottom: 20px;
     padding: 15px 20px;
-    width: 100%;
     border-radius: 5px;
 }
 .freeform-form-success p,

--- a/packages/plugin/src/templates/_templates/formatting/basic-light/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/basic-light/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/_main.css
@@ -1,9 +1,9 @@
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -24,33 +24,33 @@ button[type=submit].freeform-processing:before {
         transform: rotate(1turn);
     }
 }
-label.required:after {
+.freeform-form label.required:after {
     content: "*";
     color: #d00;
     margin-left: 3px;
 }
-.alert p:last-of-type {
+.freeform-form .alert p:last-of-type {
     margin-bottom: 0;
 }
-.mt-n1 {
+.freeform-form .mt-n1 {
     margin-top: -0.5rem !important;
 }
 
 /* DARK MODE SPECIFIC STYLES */
-.opinion-scale .opinion-scale-scales>: first-child>label {
+.freeform-form .opinion-scale .opinion-scale-scales>: first-child>label {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
 }
-.opinion-scale .opinion-scale-scales>:last-child>label {
+.freeform-form .opinion-scale .opinion-scale-scales>:last-child>label {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
 }
-.opinion-scale .opinion-scale-scales li label {
+.freeform-form .opinion-scale .opinion-scale-scales li label {
     color: #fff !important;
     border-color: #495057 !important;
     background: #1a1d20 !important;
 }
-.opinion-scale .opinion-scale-scales>* input:checked~label {
+.freeform-form .opinion-scale .opinion-scale-scales>* input:checked~label {
     color: #fff !important;
     background: #495057 !important;
 }

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/fields/table.twig
@@ -1,7 +1,4 @@
 {{ field.render({
-    instructionsBelowField: false,
-    addButtonLabel: "Add +",
-    removeButtonLabel: "x",
     tableAttributes: {
         table: { class: "table table-sm table-borderless" },
         input: { class: "form-control bg-dark-subtle text-white" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-dark/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "row" },
         success: { class: "alert alert-success" },
         errors: { class: "alert alert-danger" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/_main.css
@@ -1,9 +1,9 @@
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -24,19 +24,19 @@ button[type=submit].freeform-processing:before {
         transform: rotate(1turn);
     }
 }
-label.required:after {
+.freeform-form label.required:after {
     content: "*";
     color: #d00;
     margin-left: 3px;
 }
-.alert p:last-of-type {
+.freeform-form .alert p:last-of-type {
     margin-bottom: 0;
 }
-.mt-n1 {
+.freeform-form .mt-n1 {
     margin-top: -0.5rem !important;
 }
 
 /* FLOATING LABELS SPECIFIC STYLES */
-.form-floating > label {
+.freeform-form .form-floating > label {
     left: 12px;
 }

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/fields/table.twig
@@ -1,7 +1,4 @@
 {{ field.render({
-    instructionsBelowField: false,
-    addButtonLabel: "Add +",
-    removeButtonLabel: "x",
     tableAttributes: {
         table: { class: "table table-sm table-borderless" },
         input: { class: "form-control" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5-floating-labels/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "row" },
         success: { class: "alert alert-success" },
         errors: { class: "alert alert-danger" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5/_main.css
@@ -1,9 +1,9 @@
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -24,14 +24,14 @@ button[type=submit].freeform-processing:before {
         transform: rotate(1turn);
     }
 }
-label.required:after {
+.freeform-form label.required:after {
     content: "*";
     color: #d00;
     margin-left: 3px;
 }
-.alert p:last-of-type {
+.freeform-form .alert p:last-of-type {
     margin-bottom: 0;
 }
-.mt-n1 {
+.freeform-form .mt-n1 {
     margin-top: -0.5rem !important;
 }

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5/fields/table.twig
@@ -1,7 +1,4 @@
 {{ field.render({
-    instructionsBelowField: false,
-    addButtonLabel: "Add +",
-    removeButtonLabel: "x",
     tableAttributes: {
         table: { class: "table table-sm table-borderless" },
         input: { class: "form-control" },

--- a/packages/plugin/src/templates/_templates/formatting/bootstrap-5/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/bootstrap-5/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "row" },
         success: { class: "alert alert-success" },
         errors: { class: "alert alert-danger" },

--- a/packages/plugin/src/templates/_templates/formatting/conversational/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/conversational/_main.css
@@ -1,11 +1,13 @@
 /* LAYOUT */
 html, body {
-    font-family: sans-serif;
     margin: 0 auto;
     padding: 0;
     height: 100%;
     width: 100%;
     scroll-behavior: smooth;
+}
+.freeform-form {
+    font-family: sans-serif;
 }
 .freeform-page {
     background: #212529;
@@ -61,7 +63,6 @@ html, body {
     margin-right: auto;
     margin-bottom: 20px;
     padding: 15px 20px;
-    width: 100%;
     border-radius: 5px;
 }
 .freeform-form-success p,
@@ -91,10 +92,10 @@ html, body {
 }
 
 /* BUTTONS */
-div[data-freeform-controls] {
+.freeform-form [data-freeform-controls] {
     display: none;
 }
-button,
+.freeform-form button,
 .freeform-buttons a {
     font: 400 16px sans-serif;
     line-height: 1.5;
@@ -114,13 +115,13 @@ button,
 .freeform-buttons {
     justify-content: center;
 }
-.freeform-buttons a, .submit-button {
+.freeform-buttons a, .freeform-buttons button {
     font: 400 22px sans-serif;
     border: 1px solid #0d6efd;
     background-color: #0d6efd;
     padding: 10px 25px;
 }
-.freeform-buttons a:hover, .submit-button:hover {
+.freeform-buttons a:hover, .freeform-buttons button:hover {
     color: #ffffff;
     background-color: #0b5ed7;
     border-color: #0a58ca;
@@ -155,7 +156,6 @@ label.freeform-required:after {
     padding: 0;
     list-style: none;
     display: block;
-    width: 100%;
 }
 .freeform-fieldtype-radios .freeform-errors,
 .freeform-fieldtype-checkboxes .freeform-errors {
@@ -169,9 +169,9 @@ label.freeform-required:after {
 .freeform-errors > li:not(:first-child) {
     margin-top: 3px;
 }
-input,
-textarea,
-select {
+.freeform-form input,
+.freeform-form textarea,
+.freeform-form select {
     font: normal 25px sans-serif;
     color: #ffffff;
     background-color: transparent;
@@ -182,30 +182,30 @@ select {
     display: block;
     resize: none;
 }
-input:focus,
-textarea:focus,
-select:focus {
+.freeform-form input:focus,
+.freeform-form textarea:focus,
+.freeform-form select:focus {
     border-bottom: 2px solid #0b5ed7;
     outline: 0;
     transition: border-color .15s ease-in-out;
 }
-input::placeholder,
-textarea::placeholder {
+.freeform-form input::placeholder,
+.freeform-form textarea::placeholder {
     font: italic 200 18px sans-serif;
     color: #6c757d;
 }
-input.freeform-has-errors,
-textarea.freeform-has-errors,
-select.freeform-has-errors {
+.freeform-form input.freeform-has-errors,
+.freeform-form textarea.freeform-has-errors,
+.freeform-form select.freeform-has-errors {
     border-bottom: 2px solid #dc3545;
 }
 
 /* RADIOS, CHECKBOXES & MULTI-SELECT FIELDS */
-input[type="radio"],
-input[type="checkbox"] {
+.freeform-form input[type="radio"],
+.freeform-form input[type="checkbox"] {
     display: none;
 }
-select["multiple"] {
+.freeform-form select["multiple"] {
     display: none;
 }
 .freeform-fieldtype-radios label:not(:first-child),
@@ -252,22 +252,22 @@ select["multiple"] {
 .freeform-fieldtype-multiple-select .freeform-has-errors + label:not(:first-child) {
     border: 1px dashed #dc3545;
 }
-input[type="radio"]:checked + label,
-input[type="checkbox"]:checked + label {
+.freeform-form input[type="radio"]:checked + label,
+.freeform-form input[type="checkbox"]:checked + label {
     color: #0d6efd;
     background-color: #1a1d20;
     border: 1px solid #0d6efd;
     transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out;
 }
-input[type="radio"]:checked + label:after,
-input[type="checkbox"]:checked + label:after {
+.freeform-form input[type="radio"]:checked + label:after,
+.freeform-form input[type="checkbox"]:checked + label:after {
     font: normal 18px sans-serif;
     color: #ffffff;
     content: "✓";
     margin-left: 15px;
 }
-input[type="radio"]:checked + label span,
-input[type="checkbox"]:checked + label span {
+.freeform-form input[type="radio"]:checked + label span,
+.freeform-form input[type="checkbox"]:checked + label span {
     color: #ffffff;
     background-color: #0d6efd;
     border: 1px solid #0d6efd;
@@ -554,7 +554,7 @@ input[type="checkbox"]:checked + label span {
 }
 
 /* SUBMIT LOADING INDICATOR */
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: -ms-inline-flexbox;
     display: inline-flex;
     -ms-flex-wrap: nowrap;
@@ -562,7 +562,7 @@ button[type=submit].freeform-processing {
     -ms-flex-align: center;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: '';
     display: block;
     -ms-flex: 1 0 11px;
@@ -576,7 +576,7 @@ button[type=submit].freeform-processing:before {
     border-radius: 50%;
     animation: freeform-processing .5s linear infinite;
 }
-button:disabled {
+.freeform-form button:disabled {
     color: #ffffff;
     background-color: #5082cc;
     border-color: #497bc5;

--- a/packages/plugin/src/templates/_templates/formatting/conversational/_row.twig
+++ b/packages/plugin/src/templates/_templates/formatting/conversational/_row.twig
@@ -35,7 +35,7 @@
                         <a href="#q{{ questionId + '1' }}">Next</a>
                     {% endif %}
                     {% if questionId == questionTotal %}
-                        <button type="submit" class="submit-button" data-freeform-action="submit">Submit</button>
+                        <button type="submit" data-button-container="submit" data-freeform-action="submit">Submit</button>
                     {% endif %}
                     {% if questionId > "1" %}
                         <a href="#q{{ questionId - '1' }}" class="previous">Previous</a>

--- a/packages/plugin/src/templates/_templates/formatting/conversational/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/conversational/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/flexbox.twig
+++ b/packages/plugin/src/templates/_templates/formatting/flexbox.twig
@@ -1,11 +1,11 @@
 {# CSS styling #}
 <style>
-    button[type=submit].freeform-processing {
+    .freeform-form button[type=submit].freeform-processing {
         display: inline-flex;
         flex-wrap: nowrap;
         align-items: center;
     }
-    button[type=submit].freeform-processing:before {
+    .freeform-form button[type=submit].freeform-processing:before {
         content: "";
         display: block;
         flex: 1 0 11px;
@@ -119,6 +119,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/foundation-6/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/foundation-6/_main.css
@@ -1,9 +1,9 @@
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -25,31 +25,31 @@ button[type=submit].freeform-processing:before {
     }
 }
 
-.cell > label:first-child,
+.freeform-form .cell > label:first-child,
 .freeform-fieldtype-checkbox > label {
     font-weight: 600;
     margin-bottom: 2px;
 }
-input,
-textarea,
-select {
+.freeform-form input,
+.freeform-form textarea,
+.freeform-form select {
     margin-bottom: 0 !important;
 }
-.input-group-one-line label {
+.freeform-form .input-group-one-line label {
     display: inline-block;
     margin: 0 15px 0 0;
 }
-input[type="radio"],
-input[type="checkbox"] {
+.freeform-form input[type="radio"],
+.freeform-form input[type="checkbox"] {
     margin: 0 7px 0 0;
     padding: 0;
 }
-input[type="radio"] + label,
-input[type="checkbox"] + label {
+.freeform-form input[type="radio"] + label,
+.freeform-form input[type="checkbox"] + label {
     margin: 0;
     padding: 0;
 }
-label.required:after {
+.freeform-form label.required:after {
     content: "*";
     margin-left: 3px;
     color: red;
@@ -79,22 +79,22 @@ label.required:after {
     border-bottom: none;
     background: lightgray;
 }
-.grid-margin-x {
+.freeform-form .grid-margin-x {
     padding: 7px 0;
 }
-.errors {
+.freeform-form .errors {
     color: red;
     margin-bottom: 0 !important;
 }
-.help-text {
+.freeform-form .help-text {
     color: gray;
     line-height: 1.8;
     margin-top: -8px;
     margin-bottom: 2px;
 }
-.has-error {
+.freeform-form .has-error {
     border: 1px solid red;
 }
-.submit-buttons {
+.freeform-form .submit-buttons {
     margin-top: 20px !important;
 }

--- a/packages/plugin/src/templates/_templates/formatting/foundation-6/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/foundation-6/fields/table.twig
@@ -1,9 +1,6 @@
 {% set tableColumnCount = field.tableLayout|length %}
 
 {{ field.render({
-    instructionsBelowField: false,
-    addButtonLabel: "Add +",
-    removeButtonLabel: "x",
     tableAttributes: {
         table: { class: "table-field" },
         row: { class: "table-row" },

--- a/packages/plugin/src/templates/_templates/formatting/foundation-6/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/foundation-6/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "grid-x grid-margin-x" },
         success: { class: "callout success" },
         errors: { class: "callout alert" },

--- a/packages/plugin/src/templates/_templates/formatting/grid.twig
+++ b/packages/plugin/src/templates/_templates/formatting/grid.twig
@@ -1,11 +1,11 @@
 {# CSS styling #}
 <style>
-    button[type=submit].freeform-processing {
+    .freeform-form button[type=submit].freeform-processing {
         display: inline-flex;
         flex-wrap: nowrap;
         align-items: center;
     }
-    button[type=submit].freeform-processing:before {
+    .freeform-form button[type=submit].freeform-processing:before {
         content: "";
         display: block;
         flex: 1 0 11px;
@@ -154,6 +154,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/_main.css
@@ -1,8 +1,6 @@
 /* LAYOUT */
-html, body {
+.freeform-form {
     font-family: sans-serif;
-}
-* {
     box-sizing: border-box;
 }
 .freeform-row::after {
@@ -16,7 +14,7 @@ html, body {
 }
 
 /* BUTTONS */
-button {
+.freeform-form button {
     font: 400 18px sans-serif;
     line-height: 1.5;
     color: #ffffff;
@@ -33,32 +31,31 @@ button {
     transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out;
     justify-content: center;
 }
-button:only-child,
-button:last-child {
+.freeform-form button:only-child,
+.freeform-form button:last-child {
     margin-right: 0;
 }
-button:hover {
+.freeform-form button:hover {
     color: #ffffff;
     background-color: #0b5ed7;
     border-color: #0a58ca;
 }
-button[data-freeform-action="back"] {
-    font: 400 18px sans-serif;
+.freeform-form button[data-freeform-action="back"] {
     color: #6c757d;
     background-color: transparent;
     border-color: #6c757d;
 }
-button[data-freeform-action="back"]:hover {
+.freeform-form button[data-freeform-action="back"]:hover {
     color: #ffffff;
     background-color: #6c757d;
     border-color: #6c757d;
 }
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -71,7 +68,7 @@ button[type=submit].freeform-processing:before {
     border-radius: 50%;
     animation: freeform-processing .5s linear infinite;
 }
-button:disabled {
+.freeform-form button:disabled {
     color: #ffffff;
     background-color: #5082cc;
     border-color: #497bc5;
@@ -270,7 +267,6 @@ button:disabled {
     padding: 0;
     list-style: none;
     display: block;
-    width: 100%;
 }
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-radios .freeform-errors,
 .freeform-row [class*="freeform-col-"].freeform-fieldtype-checkboxes .freeform-errors {
@@ -469,7 +465,6 @@ button:disabled {
     margin-right: auto;
     margin-bottom: 20px;
     padding: 15px 20px;
-    width: 100%;
     border-radius: 5px;
 }
 .freeform-form-success p,

--- a/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/multipage-all-fields/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "freeform-row" },
         success: { class: "freeform-form-success" },
         errors: { class: "freeform-form-errors" },

--- a/packages/plugin/src/templates/_templates/formatting/tailwind-3/_main.css
+++ b/packages/plugin/src/templates/_templates/formatting/tailwind-3/_main.css
@@ -1,21 +1,19 @@
 /* LAYOUT */
-html, body {
+.freeform-form {
     font-family: sans-serif;
-}
-* {
     box-sizing: border-box;
 }
-.required::after {
+.freeform-form .required::after {
     content: "*";
     color: #d00;
     margin-left: 5px;
 }
-button[type=submit].freeform-processing {
+.freeform-form button[type=submit].freeform-processing {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 }
-button[type=submit].freeform-processing:before {
+.freeform-form button[type=submit].freeform-processing:before {
     content: "";
     display: block;
     flex: 1 0 11px;
@@ -36,7 +34,7 @@ button[type=submit].freeform-processing:before {
         transform: rotate(1turn);
     }
 }
-.input-group-one-line > div {
+.freeform-form .input-group-one-line > div {
     float: left;
     margin-right: 15px;
 }

--- a/packages/plugin/src/templates/_templates/formatting/tailwind-3/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/tailwind-3/fields/table.twig
@@ -10,7 +10,7 @@
             "table-col pb-1"
         ] },
         label: { class: [
-            "text-left font-medium tracking-wide text-slate-800 text-sm mb-2 pr-5"
+            "text-left"
         ] },
         input: { class: [ field.attributes.input.get("class"), "mr-5 w-11/12 block" ] },
         dropdown: { class: [ field.attributes.input.get("class"), "mr-5 w-11/12 block" ] },

--- a/packages/plugin/src/templates/_templates/formatting/tailwind-3/fields/table.twig
+++ b/packages/plugin/src/templates/_templates/formatting/tailwind-3/fields/table.twig
@@ -1,9 +1,6 @@
 {% set tableColumnCount = field.tableLayout|length %}
 
 {{ field.render({
-    instructionsBelowField: false,
-    addButtonLabel: "Add +",
-    removeButtonLabel: "x",
     tableAttributes: {
         table: { class: "table" },
         row: { class: "table-row" },

--- a/packages/plugin/src/templates/_templates/formatting/tailwind-3/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/tailwind-3/index.twig
@@ -56,6 +56,11 @@
                 input: { "-class": "appearance-none block w-full" },
             },
         },
+        "@table": {
+            attributes: {
+                label: { "-class": "block" },
+            },
+        },
         "@signature": {
             attributes: {
                 input: { "+class": "rounded py-1 px-2 mr-1 hover:bg-slate-400" },

--- a/packages/plugin/src/templates/_templates/formatting/tailwind-3/index.twig
+++ b/packages/plugin/src/templates/_templates/formatting/tailwind-3/index.twig
@@ -7,6 +7,7 @@
 {# Render the opening form tag #}
 {{ form.renderTag({
     attributes: {
+        form: { class: "freeform-form" },
         row: { class: "flex flex-wrap -mx-2 mb-4" },
         success: { class: "bg-green-100 border border-green-400 font-bold text-green-700 px-4 py-3 rounded relative mb-4" },
         errors: { class: "bg-red-100 border border-red-400 font-bold text-red-700 px-4 py-3 rounded relative mb-4" },


### PR DESCRIPTION
### Related Ticket Number
[SFT-1144](https://solspace.atlassian.net/browse/SFT-1144)
#1277
#1297

### Description
- Table field template attribute overrides were not working at all. This corrects that issue.
- Sample formatting templates contains a handful of minor display issues and forced some global CSS styles, which would conflict with regular site CSS. This corrects that issue as well.

[SFT-1144]: https://solspace.atlassian.net/browse/SFT-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ