### PR TITLE
fix(SFT-1149): Twig Template Loading Error - Unable to find the template 'freeform/C:\'

### DIFF
--- a/packages/plugin/src/Services/FormsService.php
+++ b/packages/plugin/src/Services/FormsService.php
@@ -341,7 +341,9 @@ class FormsService extends BaseService implements FormHandlerInterface
                 if (str_ends_with($template->getFilePath(), $templateName)) {
                     $templatePath = $template->getFilePath();
                     $templatePath = str_replace(\Craft::getAlias('@freeform/templates/'), '', $templatePath);
-                    $templatePath = 'freeform/'.$templatePath;
+                    if (\DIRECTORY_SEPARATOR === '/') {
+                        $templatePath = 'freeform/'.$templatePath;
+                    }
                     $templateMode = View::TEMPLATE_MODE_CP;
 
                     break;


### PR DESCRIPTION
### Related Ticket

https://solspace.atlassian.net/browse/SFT-1149

Use directory separator to detect OS and append "freeform" to template path if using Unix, Linux or Mac.

```
if (DIRECTORY_SEPARATOR === '/') {
    // unix, linux, mac
}

if (DIRECTORY_SEPARATOR === '\\' || strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
    // windows
}
```