### PR TITLE
fix(SFT-1153): Allow en dash and em dash characters on save

### DIFF
--- a/packages/plugin/src/Elements/Submission.php
+++ b/packages/plugin/src/Elements/Submission.php
@@ -14,7 +14,6 @@ use craft\helpers\Db;
 use craft\helpers\Html;
 use craft\helpers\StringHelper as CraftStringHelper;
 use craft\helpers\UrlHelper;
-use LitEmoji\LitEmoji;
 use Solspace\Freeform\Bundles\GraphQL\GqlPermissions;
 use Solspace\Freeform\Elements\Actions\DeleteAllSubmissionsAction;
 use Solspace\Freeform\Elements\Actions\DeleteSubmissionAction;
@@ -460,7 +459,7 @@ class Submission extends Element
             }
 
             if (\PHP_VERSION_ID >= 50400 && null !== $value) {
-                $value = LitEmoji::unicodeToShortcode($value);
+                $value = CraftStringHelper::emojiToShortcodes($value);
             }
 
             $event = new ProcessFieldValueEvent($field, $value);


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/discussions/1316

EN (–) and EM (—) dash characters get striped out on save because we pass the field values through `LitEmoji::unicodeToShortcode` instead of Craft's `StringHelpers::emojiToShortcodes`, which applies an additional workaround on top to allow EN and EM dashes. `LitEmoji::unicodeToShortcode` is still applied afterwards.

See: https://github.com/craftcms/cms/blob/c2422906dd067b64c6270e42013566f6c2a2d03f/src/helpers/StringHelper.php#L295

https://github.com/craftcms/cms/commit/263ead7bc74a4654d62c293b5f9a83369a59ea07