### PR TITLE
fix(SFT-1153): Allow en dash and em dash characters on save

### DIFF
--- a/packages/plugin/src/Elements/Submission.php
+++ b/packages/plugin/src/Elements/Submission.php
@@ -12,7 +12,6 @@ use craft\events\RegisterElementActionsEvent;
 use craft\helpers\Html;
 use craft\helpers\StringHelper as CraftStringHelper;
 use craft\helpers\UrlHelper;
-use LitEmoji\LitEmoji;
 use Solspace\Commons\Helpers\CryptoHelper;
 use Solspace\Commons\Helpers\PermissionHelper;
 use Solspace\Commons\Helpers\StringHelper;
@@ -449,8 +448,8 @@ class Submission extends Element
                 $value = json_encode($value);
             }
 
-            if (\PHP_VERSION_ID >= 50400) {
-                $value = LitEmoji::unicodeToShortcode($value);
+            if (\PHP_VERSION_ID >= 50400 && null !== $value) {
+                $value = CraftStringHelper::emojiToShortcodes($value);
             }
 
             $contentData[self::getFieldColumnName($field)] = $value;

--- a/packages/plugin/src/Services/DiagnosticsService.php
+++ b/packages/plugin/src/Services/DiagnosticsService.php
@@ -36,7 +36,7 @@ class DiagnosticsService extends BaseService
                         'You have an incompatible version of Craft installed. This version of Freeform currently supports Craft 4.0.0 and greater.'
                     ),
                     new SuggestionValidator(
-                        fn ($value) => version_compare($value['version'], '4.9.0', '<'),
+                        fn ($value) => version_compare($value['version'], '4.10.0', '<'),
                         'Potential Craft Compatibility issue',
                         "The current version of Freeform installed may not be fully compatible with the version of Craft installed. Please confirm you're using a version of Freeform tested for compatibility with this version of Craft."
                     ),
@@ -52,7 +52,7 @@ class DiagnosticsService extends BaseService
                         'You have an incompatible version of PHP installed for this site environment. This version of Freeform currently supports PHP 8.0.2 and greater.'
                     ),
                     new SuggestionValidator(
-                        fn ($value) => version_compare($value, '8.2', '<'),
+                        fn ($value) => version_compare($value, '8.3', '<'),
                         'Potential PHP Compatibility issue',
                         "The current version of Freeform installed may not be fully compatible with the version of PHP installed for this site environment. Please confirm you're using a version of Freeform tested for compatibility with this version of PHP."
                     ),
@@ -239,23 +239,19 @@ class DiagnosticsService extends BaseService
                 [
                     'isPro' => Freeform::getInstance()->isPro(),
                     'version' => Freeform::getInstance()->getVersion(),
+                ],
+                [
+                    new SuggestionValidator(
+                        fn ($value) => version_compare($value['version'], '5.0.0', '>='),
+                        'A new major version of Freeform is available!',
+                        '<a href="{{ extra.url }}">Update to Freeform 5</a> to unlock an impressive new form-building experience, flexible templating options and much more! Freeform 5 is compatible with both Craft 4 and Craft 5.',
+                        ['url' => 'https://docs.solspace.com/craft/freeform/v5/']
+                    ),
                 ]
             ),
             new DiagnosticItem(
                 'Craft Email configuration: <b>{{ value.transport }}</b>',
-                ['transport' => $emailTransport, 'issues' => $emailIssues],
-                [
-                    new SuggestionValidator(
-                        fn ($value) => 'misaligned_from' !== $value['issues'],
-                        'Potential Email Configuration issue',
-                        "When using SMTP for the Craft Email settings, the 'From Email' in email notification templates should always contain a matching email address, otherwise the notifications may not send. If you wish to have a different email address for this, consider using 'Reply to Email' instead."
-                    ),
-                    new NoticeValidator(
-                        fn ($value) => 'misaligned_from' !== $value['issues'],
-                        'Potential Email Configuration issue',
-                        "We've detected that you're using SMTP and have email notification template(s) that contain an email address for the 'From Email' that does not match the email address configured in the Craft Email settings."
-                    ),
-                ]
+                ['transport' => $emailTransport, 'issues' => $emailIssues]
             ),
             'Spam settings' => [
                 new DiagnosticItem(


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/discussions/1316

EN (–) and EM (—) dash characters get striped out on save because we pass the field values through `LitEmoji::unicodeToShortcode` instead of Craft's `StringHelpers::emojiToShortcodes`, which applies an additional workaround on top to allow EN and EM dashes. `LitEmoji::unicodeToShortcode` is still applied afterwards.

See: https://github.com/craftcms/cms/blob/c2422906dd067b64c6270e42013566f6c2a2d03f/src/helpers/StringHelper.php#L295

https://github.com/craftcms/cms/commit/263ead7bc74a4654d62c293b5f9a83369a59ea07