### PR TITLE
fix(#1327): duplicate form listing in submissions/spam

### DIFF
--- a/packages/plugin/src/Elements/Submission.php
+++ b/packages/plugin/src/Elements/Submission.php
@@ -617,17 +617,7 @@ class Submission extends Element
                     ],
                 ];
             }
-            $items[] = ['heading' => ''];
-            $items[] = [
-                'key' => 'form:'.$form->getId(),
-                'label' => $form->getName(),
-                'data' => [
-                    'handle' => $form->getHandle(),
-                ],
-                'criteria' => [
-                    'formId' => $form->getId(),
-                ],
-            ];
+
             $sources = $items;
         }
 


### PR DESCRIPTION
* fixing duplicate display of the last form in submissions/spam listings