### PR TITLE
[#1385]: Notification jobs not containing submissions

### DIFF
--- a/packages/plugin/src/Bundles/Notifications/SendListeners/AdminNotifications.php
+++ b/packages/plugin/src/Bundles/Notifications/SendListeners/AdminNotifications.php
@@ -62,6 +62,7 @@ class AdminNotifications extends FeatureBundle
             $this->queueHandler->executeNotificationJob(
                 new SendNotificationsJob([
                     'formId' => $form->getId(),
+                    'submissionId' => $event->getSubmission()->id,
                     'postedData' => $postedData,
                     'recipients' => $recipients,
                     'template' => $template,

--- a/packages/plugin/src/Bundles/Notifications/SendListeners/ConditionalNotifications.php
+++ b/packages/plugin/src/Bundles/Notifications/SendListeners/ConditionalNotifications.php
@@ -110,6 +110,7 @@ class ConditionalNotifications extends FeatureBundle
             $this->queueHandler->executeNotificationJob(
                 new SendNotificationsJob([
                     'formId' => $form->getId(),
+                    'submissionId' => $event->getSubmission()->id,
                     'postedData' => $postedData,
                     'recipients' => $recipients,
                     'template' => $template,

--- a/packages/plugin/src/Bundles/Notifications/SendListeners/DynamicRecipients.php
+++ b/packages/plugin/src/Bundles/Notifications/SendListeners/DynamicRecipients.php
@@ -80,6 +80,7 @@ class DynamicRecipients extends FeatureBundle
                 $this->queueHandler->executeNotificationJob(
                     new SendNotificationsJob([
                         'formId' => $form->getId(),
+                        'submissionId' => $event->getSubmission()->id,
                         'postedData' => $postedData,
                         'recipients' => $recipients,
                         'template' => $template,

--- a/packages/plugin/src/Bundles/Notifications/SendListeners/DynamicTemplateRecipients.php
+++ b/packages/plugin/src/Bundles/Notifications/SendListeners/DynamicTemplateRecipients.php
@@ -73,6 +73,7 @@ class DynamicTemplateRecipients extends FeatureBundle
         $this->queueHandler->executeNotificationJob(
             new SendNotificationsJob([
                 'formId' => $form->getId(),
+                'submissionId' => $event->getSubmission()->id,
                 'postedData' => $postedData,
                 'recipients' => $recipientCollection,
                 'template' => $notificationTemplate,

--- a/packages/plugin/src/Bundles/Notifications/SendListeners/EmailRecipientNotifications.php
+++ b/packages/plugin/src/Bundles/Notifications/SendListeners/EmailRecipientNotifications.php
@@ -72,6 +72,7 @@ class EmailRecipientNotifications extends FeatureBundle
             $this->queueHandler->executeNotificationJob(
                 new SendNotificationsJob([
                     'formId' => $form->getId(),
+                    'submissionId' => $event->getSubmission()->id,
                     'postedData' => $postedData,
                     'recipients' => $recipientCollection,
                     'template' => $notificationTemplate,

--- a/packages/plugin/src/Jobs/SendNotificationsJob.php
+++ b/packages/plugin/src/Jobs/SendNotificationsJob.php
@@ -21,6 +21,8 @@ class SendNotificationsJob extends BaseJob implements NotificationJobInterface
 {
     public ?int $formId = null;
 
+    public ?int $submissionId = null;
+
     public array $postedData = [];
 
     public ?RecipientCollection $recipients = null;
@@ -46,10 +48,13 @@ class SendNotificationsJob extends BaseJob implements NotificationJobInterface
 
         $form->valuesFromArray($this->postedData);
 
+        $submission = $freeform->submissions->getSubmissionById($this->submissionId);
+
         $freeform->mailer->sendEmail(
             $form,
             $this->recipients,
             $this->template,
+            $submission,
         );
     }
 


### PR DESCRIPTION
### Related Ticket Number
#1385

### Description
Ever since the introduction of Job Queue for notifications, the submission element has become unavailable to the notification templates. This has been fixed, and the submission is available again.

- fixes
