### PR TITLE
[#1388]: Element integrations throwing errors on pages without mapped fields

### DIFF
--- a/packages/plugin/src/Bundles/Integrations/Elements/ElementFieldMappingHelper.php
+++ b/packages/plugin/src/Bundles/Integrations/Elements/ElementFieldMappingHelper.php
@@ -26,9 +26,15 @@ class ElementFieldMappingHelper
 
         foreach ($errors as $craftField => $errorList) {
             if (isset($sourceToField[$craftField])) {
-                $sourceToField[$craftField]->addErrors($errorList);
+                $field = $sourceToField[$craftField];
+
+                if ($form->getCurrentPage()->getFields()->has($field)) {
+                    $field->addErrors($errorList);
+                }
             } else {
-                $form->addErrors($errorList);
+                if ($form->isLastPage()) {
+                    $form->addErrors($errorList);
+                }
             }
         }
     }


### PR DESCRIPTION
### Related Ticket Number
#1388

### Description
When mapping required element fields to form fields that are on pages that aren't the first page, an error is thrown in the validation process about the fields being required, but them not being visible would prevent the user from being able to go forward.

- triggering element global form errors on last page only
- triggering element field errors on pages which contain those fields
