### PR TITLE
[#1389]: Notifications not rendering all fields from all pages

### DIFF
--- a/packages/plugin/src/Services/MailerService.php
+++ b/packages/plugin/src/Services/MailerService.php
@@ -73,7 +73,7 @@ class MailerService extends BaseService implements MailHandlerInterface
         }
 
         $recipients = $this->processRecipients($recipients);
-        $fields = $form->getFields();
+        $fields = $form->getLayout()->getFields();
 
         $fieldValues = $this->getFieldValues($fields, $form, $submission);
         $renderEvent = new RenderEmailEvent($form, $notificationTemplate, $fieldValues, $submission);


### PR DESCRIPTION
### Related Ticket Number
#1389

### Description
When using `allFields` in notification templates, it would only use the first page fields rather than all fields from all pages.

- using all fields from all pages for the `allFields` variable
