### PR TITLE
[SFT-1244]: Failing integrations gracefully

### DIFF
--- a/packages/plugin/src/Services/Integrations/IntegrationsService.php
+++ b/packages/plugin/src/Services/Integrations/IntegrationsService.php
@@ -487,7 +487,11 @@ class IntegrationsService extends BaseService
         $integrations = $this->getForForm($form, $type, true);
         foreach ($integrations as $integration) {
             $client = $this->clientProvider->getAuthorizedClient($integration);
-            $integration->push($form, $client);
+
+            try {
+                $integration->push($form, $client);
+            } catch (IntegrationException $e) {
+            }
         }
     }
 


### PR DESCRIPTION
Once an integration fails, it no longer prevents the form from being submitted. Instead it proceeds after logging an error.