### PR TITLE
[SFT-1256]: Notification job failure when not storing submissions

### DIFF
--- a/packages/plugin/src/Services/SubmissionsService.php
+++ b/packages/plugin/src/Services/SubmissionsService.php
@@ -52,8 +52,12 @@ class SubmissionsService extends BaseService implements SubmissionHandlerInterfa
     private static array $submissionCache = [];
     private static array $submissionTokenCache = [];
 
-    public function getSubmissionById(int $id): ?Submission
+    public function getSubmissionById(?int $id): ?Submission
     {
+        if (null === $id) {
+            return null;
+        }
+
         if (!isset(self::$submissionCache[$id])) {
             self::$submissionCache[$id] = Submission::find()->id($id)->one();
         }


### PR DESCRIPTION
### Related Ticket Number
[SFT-1256](https://solspace.atlassian.net/browse/SFT-1256)
#1364

### Description
Notification jobs would fail when the form wasn't storing submissions. This has been fixed now.


[SFT-1256]: https://solspace.atlassian.net/browse/SFT-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ