### PR TITLE
[SFT-1310]: Refresh Token issues on ZOHO

### DIFF
--- a/packages/plugin/src/Events/Integrations/FailedRequestEvent.php
+++ b/packages/plugin/src/Events/Integrations/FailedRequestEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Solspace\Freeform\Events\Integrations;
+
+use craft\events\CancelableEvent;
+use Solspace\Freeform\Library\Integrations\IntegrationInterface;
+
+class FailedRequestEvent extends CancelableEvent
+{
+    private bool $retry = false;
+
+    public function __construct(
+        private IntegrationInterface $integration,
+        private \Exception $exception,
+    ) {
+        parent::__construct();
+    }
+
+    public function getIntegration(): IntegrationInterface
+    {
+        return $this->integration;
+    }
+
+    public function getException(): \Exception
+    {
+        return $this->exception;
+    }
+
+    public function isRetry(): bool
+    {
+        return $this->retry;
+    }
+
+    public function triggerRetry(): void
+    {
+        $this->retry = true;
+    }
+}

--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/BaseActiveCampaignIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/BaseActiveCampaignIntegration.php
@@ -127,25 +127,21 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
         $pipelineId = null;
 
-        try {
-            $response = $client->get(
-                $this->getEndpoint('/dealGroups'),
-                [
-                    'query' => [
-                        'filters[title]' => $pipeline,
-                    ],
+        $response = $client->get(
+            $this->getEndpoint('/dealGroups'),
+            [
+                'query' => [
+                    'filters[title]' => $pipeline,
                 ],
-            );
+            ],
+        );
 
-            $json = json_decode($response->getBody(), false);
+        $json = json_decode($response->getBody(), false);
 
-            if (isset($json->dealGroups) && \count($json->dealGroups)) {
-                $item = $json->dealGroups[0];
+        if (isset($json->dealGroups) && \count($json->dealGroups)) {
+            $item = $json->dealGroups[0];
 
-                $pipelineId = $item->id;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+            $pipelineId = $item->id;
         }
 
         return $pipelineId;
@@ -171,26 +167,22 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
         $stageId = null;
 
-        try {
-            $response = $client->get(
-                $this->getEndpoint('/dealStages'),
-                [
-                    'query' => [
-                        'filters[title]' => $stage,
-                        'filters[d_groupid]' => $pipelineId,
-                    ],
+        $response = $client->get(
+            $this->getEndpoint('/dealStages'),
+            [
+                'query' => [
+                    'filters[title]' => $stage,
+                    'filters[d_groupid]' => $pipelineId,
                 ],
-            );
+            ],
+        );
 
-            $json = json_decode($response->getBody(), false);
+        $json = json_decode($response->getBody(), false);
 
-            if (isset($json->dealStages) && \count($json->dealStages)) {
-                $item = $json->dealStages[0];
+        if (isset($json->dealStages) && \count($json->dealStages)) {
+            $item = $json->dealStages[0];
 
-                $stageId = $item->id;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+            $stageId = $item->id;
         }
 
         return $stageId;
@@ -207,17 +199,11 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
         }
 
         $ownerId = null;
+        $response = $client->get($this->getEndpoint('/users/username/'.$owner));
+        $json = json_decode($response->getBody(), false);
 
-        try {
-            $response = $client->get($this->getEndpoint('/users/username/'.$owner));
-
-            $json = json_decode($response->getBody(), false);
-
-            if (!empty($json->user)) {
-                $ownerId = $json->user->id;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+        if (!empty($json->user)) {
+            $ownerId = $json->user->id;
         }
 
         return $ownerId;
@@ -225,12 +211,7 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
     private function fetchContactFields(Client $client, string $category): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/fields?limit=999'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/fields?limit=999'));
         $json = json_decode((string) $response->getBody(), false);
 
         $fieldList = [];
@@ -264,11 +245,7 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
     private function fetchDealFields(Client $client, string $category): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/dealCustomFieldMeta'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $response = $client->get($this->getEndpoint('/dealCustomFieldMeta'));
 
         $json = json_decode((string) $response->getBody(), false);
 
@@ -307,17 +284,12 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
     private function fetchAccountFields(Client $client, string $category): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/accountCustomFieldMeta'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/accountCustomFieldMeta'));
         $json = json_decode((string) $response->getBody());
 
-        $fieldList = [];
-
-        $fieldList[] = new FieldObject('name', 'Name', FieldObject::TYPE_STRING, $category, true);
+        $fieldList = [
+            new FieldObject('name', 'Name', FieldObject::TYPE_STRING, $category, true),
+        ];
 
         if (isset($json->accountCustomFieldMeta)) {
             foreach ($json->accountCustomFieldMeta as $field) {

--- a/packages/plugin/src/Integrations/CRM/Freshdesk/BaseFreshdeskIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Freshdesk/BaseFreshdeskIntegration.php
@@ -113,12 +113,7 @@ abstract class BaseFreshdeskIntegration extends CRMIntegration implements Freshd
 
     public function fetchFields(string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/admin/ticket_fields'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/admin/ticket_fields'));
         $json = json_decode((string) $response->getBody(), false);
 
         if (!isset($json) || !$json) {

--- a/packages/plugin/src/Integrations/CRM/Freshdesk/Versions/FreshdeskV2.php
+++ b/packages/plugin/src/Integrations/CRM/Freshdesk/Versions/FreshdeskV2.php
@@ -59,11 +59,9 @@ class FreshdeskV2 extends BaseFreshdeskIntegration
         return $url.'/api/'.self::API_VERSION;
     }
 
-    public function push(Form $form, Client $client): bool
+    public function push(Form $form, Client $client): void
     {
         $this->processTickets($form, $client);
-
-        return true;
     }
 
     private function processTickets(Form $form, Client $client): void
@@ -165,15 +163,11 @@ class FreshdeskV2 extends BaseFreshdeskIntegration
             }
         }
 
-        try {
-            $response = $client->post(
-                $this->getEndpoint('/tickets'),
-                [$requestType => $values],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/tickets'),
+            [$requestType => $values],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_TICKET, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_TICKET, $response);
     }
 }

--- a/packages/plugin/src/Integrations/CRM/HubSpot/Versions/HubSpotV3.php
+++ b/packages/plugin/src/Integrations/CRM/HubSpot/Versions/HubSpotV3.php
@@ -127,12 +127,7 @@ class HubSpotV3 extends BaseHubSpotIntegration
     {
         $record = $this->getRecord($category);
 
-        try {
-            $response = $client->get($this->getEndpoint('/properties/'.$record));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/properties/'.$record));
         $json = json_decode((string) $response->getBody());
         if (empty($json)) {
             throw new IntegrationException('Could not fetch fields for '.$category);
@@ -178,15 +173,13 @@ class HubSpotV3 extends BaseHubSpotIntegration
         return 'https://api.hubapi.com/crm/v3';
     }
 
-    public function push(Form $form, Client $client): bool
+    public function push(Form $form, Client $client): void
     {
         $this->pushContacts($form, $client);
         $this->pushCompanies($form, $client);
         $this->pushDeals($form, $client);
 
         $this->createAssociations($form, $client);
-
-        return true;
     }
 
     private function pushContacts(Form $form, Client $client): void
@@ -212,38 +205,33 @@ class HubSpotV3 extends BaseHubSpotIntegration
             $this->getMappedProps($this->contactMapping)
         );
 
-        try {
-            if ($contact) {
-                $contactId = $contact->id;
+        if ($contact) {
+            $contactId = $contact->id;
 
-                if ($this->getAppendContactData()) {
-                    $mapping = $this->appendValues(
-                        self::CATEGORY_CONTACT,
-                        $mapping,
-                        (array) $contact->properties
-                    );
-                }
-
-                $response = $client->patch(
-                    $this->getEndpoint('/objects/contacts/'.$contactId),
-                    ['json' => ['properties' => $mapping]],
+            if ($this->getAppendContactData()) {
+                $mapping = $this->appendValues(
+                    self::CATEGORY_CONTACT,
+                    $mapping,
+                    (array) $contact->properties
                 );
-            } else {
-                [$response, $data] = $this->getJsonResponse(
-                    $client->post(
-                        $this->getEndpoint('/objects/contacts'),
-                        ['json' => ['properties' => $mapping]],
-                    )
-                );
-
-                $contactId = $data->id;
             }
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::CATEGORY_CONTACT);
+            $response = $client->patch(
+                $this->getEndpoint('/objects/contacts/'.$contactId),
+                ['json' => ['properties' => $mapping]],
+            );
+        } else {
+            [$response, $data] = $this->getJsonResponse(
+                $client->post(
+                    $this->getEndpoint('/objects/contacts'),
+                    ['json' => ['properties' => $mapping]],
+                )
+            );
+
+            $contactId = $data->id;
         }
 
+        $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT, $response);
         $this->contactId = $contactId;
     }
 
@@ -286,41 +274,36 @@ class HubSpotV3 extends BaseHubSpotIntegration
             $this->getMappedProps($this->companyMapping)
         );
 
-        try {
-            if ($company) {
-                $companyId = $company->id;
+        if ($company) {
+            $companyId = $company->id;
 
-                // Prevent the customer from updating company name if it's an existing company
-                unset($mapping['name']);
+            // Prevent the customer from updating company name if it's an existing company
+            unset($mapping['name']);
 
-                if ($this->getAppendCompanyData()) {
-                    $mapping = $this->appendValues(
-                        self::CATEGORY_COMPANY,
-                        $mapping,
-                        (array) $company->properties
-                    );
-                }
-
-                $response = $client->patch(
-                    $this->getEndpoint('/objects/companies/'.$companyId),
-                    ['json' => ['properties' => $mapping]],
+            if ($this->getAppendCompanyData()) {
+                $mapping = $this->appendValues(
+                    self::CATEGORY_COMPANY,
+                    $mapping,
+                    (array) $company->properties
                 );
-            } else {
-                [$response, $data] = $this->getJsonResponse(
-                    $client->post(
-                        $this->getEndpoint('/objects/companies'),
-                        ['json' => ['properties' => $mapping]],
-                    )
-                );
-
-                $companyId = $data->id;
             }
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_COMPANY, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::CATEGORY_COMPANY);
+            $response = $client->patch(
+                $this->getEndpoint('/objects/companies/'.$companyId),
+                ['json' => ['properties' => $mapping]],
+            );
+        } else {
+            [$response, $data] = $this->getJsonResponse(
+                $client->post(
+                    $this->getEndpoint('/objects/companies'),
+                    ['json' => ['properties' => $mapping]],
+                )
+            );
+
+            $companyId = $data->id;
         }
 
+        $this->triggerAfterResponseEvent(self::CATEGORY_COMPANY, $response);
         $this->companyId = $companyId;
     }
 
@@ -335,20 +318,15 @@ class HubSpotV3 extends BaseHubSpotIntegration
             return;
         }
 
-        try {
-            [$response, $data] = $this->getJsonResponse(
-                $client->post(
-                    $this->getEndpoint('/objects/deals'),
-                    ['json' => ['properties' => $properties]],
-                )
-            );
+        [$response, $data] = $this->getJsonResponse(
+            $client->post(
+                $this->getEndpoint('/objects/deals'),
+                ['json' => ['properties' => $properties]],
+            )
+        );
 
-            $this->dealId = $data->id;
-
-            $this->triggerAfterResponseEvent(self::CATEGORY_DEAL, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::CATEGORY_DEAL);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_DEAL, $response);
+        $this->dealId = $data->id;
     }
 
     private function createAssociations(Form $form, Client $client): void
@@ -449,25 +427,21 @@ class HubSpotV3 extends BaseHubSpotIntegration
             return null;
         }
 
-        try {
-            [, $data] = $this->getJsonResponse(
-                $client->post(
-                    $this->getEndpoint("/objects/{$record}/search"),
-                    [
-                        'json' => [
-                            'properties' => $properties,
-                            'filterGroups' => [['filters' => $filters]],
-                            'limit' => 1,
-                        ],
+        [, $data] = $this->getJsonResponse(
+            $client->post(
+                $this->getEndpoint("/objects/{$record}/search"),
+                [
+                    'json' => [
+                        'properties' => $properties,
+                        'filterGroups' => [['filters' => $filters]],
+                        'limit' => 1,
                     ],
-                )
-            );
+                ],
+            )
+        );
 
-            if ($data->total > 0) {
-                return $data->results[0];
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::CATEGORY_CONTACT);
+        if ($data->total > 0) {
+            return $data->results[0];
         }
 
         return null;

--- a/packages/plugin/src/Integrations/CRM/Insightly/Versions/InsightlyV31.php
+++ b/packages/plugin/src/Integrations/CRM/Insightly/Versions/InsightlyV31.php
@@ -58,11 +58,9 @@ class InsightlyV31 extends BaseInsightlyIntegration
         return $url.'/'.self::API_VERSION;
     }
 
-    public function push(Form $form, Client $client): bool
+    public function push(Form $form, Client $client): void
     {
         $this->processLeads($form, $client);
-
-        return true;
     }
 
     private function processLeads(Form $form, Client $client): void
@@ -76,15 +74,11 @@ class InsightlyV31 extends BaseInsightlyIntegration
             return;
         }
 
-        try {
-            $response = $client->post(
-                $this->getEndpoint('/Leads'),
-                ['json' => $mapping],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/Leads'),
+            ['json' => $mapping],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_LEAD, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_LEAD, $response);
     }
 }

--- a/packages/plugin/src/Integrations/CRM/Pardot/BasePardotIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Pardot/BasePardotIntegration.php
@@ -198,12 +198,7 @@ abstract class BasePardotIntegration extends CRMIntegration implements OAuth2Con
 
     private function getCustomFields(Client $client, string $category): array
     {
-        try {
-            $response = $client->get($this->getPardotEndpoint('customField'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getPardotEndpoint('customField'));
         $json = json_decode((string) $response->getBody());
 
         if (!$json || !isset($json->result)) {

--- a/packages/plugin/src/Integrations/CRM/Pardot/Versions/PardotV4.php
+++ b/packages/plugin/src/Integrations/CRM/Pardot/Versions/PardotV4.php
@@ -79,11 +79,9 @@ class PardotV4 extends BasePardotIntegration
         return 'https://pi.pardot.com/api';
     }
 
-    public function push(Form $form, Client $client): bool
+    public function push(Form $form, Client $client): void
     {
         $this->processProspect($form, $client);
-
-        return true;
     }
 
     protected function getPardotEndpoint(string $object = 'prospect', string $action = 'query'): string
@@ -116,19 +114,14 @@ class PardotV4 extends BasePardotIntegration
             return;
         }
 
-        try {
-            $email = $mapping['email'];
+        $email = $mapping['email'];
+        unset($mapping['email']);
 
-            unset($mapping['email']);
+        $response = $client->post(
+            $this->getPardotEndpoint('prospect', 'create/email/'.$email),
+            ['query' => $mapping],
+        );
 
-            $response = $client->post(
-                $this->getPardotEndpoint('prospect', 'create/email/'.$email),
-                ['query' => $mapping],
-            );
-
-            $this->triggerAfterResponseEvent(self::CATEGORY_PROSPECT, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_PROSPECT, $response);
     }
 }

--- a/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
@@ -89,12 +89,7 @@ abstract class BasePipedriveIntegration extends CRMIntegration implements OAuth2
 
     public function fetchFields(string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/'.strtolower($category).'Fields'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/'.strtolower($category).'Fields'));
         $json = json_decode((string) $response->getBody());
 
         if (!isset($json->success) || !$json->success) {

--- a/packages/plugin/src/Integrations/CRM/Pipedrive/Versions/PipedriveV1.php
+++ b/packages/plugin/src/Integrations/CRM/Pipedrive/Versions/PipedriveV1.php
@@ -169,14 +169,12 @@ class PipedriveV1 extends BasePipedriveIntegration
         return $url.'/api/'.self::API_VERSION;
     }
 
-    public function push(Form $form, Client $client): bool
+    public function push(Form $form, Client $client): void
     {
         $this->processOrganization($form, $client);
         $this->processPerson($form, $client);
         $this->processLeads($form, $client);
         $this->processDeals($form, $client);
-
-        return true;
     }
 
     protected function getStageId(): ?int
@@ -195,36 +193,32 @@ class PipedriveV1 extends BasePipedriveIntegration
             return;
         }
 
-        try {
-            $userId = $this->getUserId();
-            if ($userId) {
-                $mapping['owner_id'] = $userId;
-            }
+        $userId = $this->getUserId();
+        if ($userId) {
+            $mapping['owner_id'] = $userId;
+        }
 
-            $organizationId = $this->searchForDuplicate(
-                $client,
-                ['name' => $mapping['name'] ?? null],
-                'organization',
-            );
+        $organizationId = $this->searchForDuplicate(
+            $client,
+            ['name' => $mapping['name'] ?? null],
+            'organization',
+        );
 
-            if ($organizationId) {
-                $this->organizationId = $organizationId;
-            }
+        if ($organizationId) {
+            $this->organizationId = $organizationId;
+        }
 
-            $response = $client->post(
-                $this->getEndpoint('/organizations'),
-                ['json' => $mapping],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/organizations'),
+            ['json' => $mapping],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_ORGANIZATION, $response);
+        $this->triggerAfterResponseEvent(self::CATEGORY_ORGANIZATION, $response);
 
-            $json = json_decode((string) $response->getBody(), false);
+        $json = json_decode((string) $response->getBody(), false);
 
-            if (isset($json->data->id)) {
-                $this->organizationId = (int) $json->data->id;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+        if (isset($json->data->id)) {
+            $this->organizationId = (int) $json->data->id;
         }
     }
 
@@ -245,39 +239,35 @@ class PipedriveV1 extends BasePipedriveIntegration
             'person',
         );
 
-        try {
-            $userId = $this->getUserId();
-            if ($userId) {
-                $mapping['owner_id'] = $userId;
-            }
+        $userId = $this->getUserId();
+        if ($userId) {
+            $mapping['owner_id'] = $userId;
+        }
 
-            if ($this->organizationId) {
-                $mapping['org_id'] = $this->organizationId;
-            }
+        if ($this->organizationId) {
+            $mapping['org_id'] = $this->organizationId;
+        }
 
-            if ($personId) {
-                unset($mapping['email']);
+        if ($personId) {
+            unset($mapping['email']);
 
-                $response = $client->put(
-                    $this->getEndpoint('/persons/'.$personId),
-                    ['json' => $mapping],
-                );
-            } else {
-                $response = $client->post(
-                    $this->getEndpoint('/persons'),
-                    ['json' => $mapping],
-                );
-            }
+            $response = $client->put(
+                $this->getEndpoint('/persons/'.$personId),
+                ['json' => $mapping],
+            );
+        } else {
+            $response = $client->post(
+                $this->getEndpoint('/persons'),
+                ['json' => $mapping],
+            );
+        }
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_PERSON, $response);
+        $this->triggerAfterResponseEvent(self::CATEGORY_PERSON, $response);
 
-            $json = json_decode((string) $response->getBody(), false);
+        $json = json_decode((string) $response->getBody(), false);
 
-            if (isset($json->data->id)) {
-                $this->personId = (int) $json->data->id;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+        if (isset($json->data->id)) {
+            $this->personId = (int) $json->data->id;
         }
     }
 
@@ -292,55 +282,51 @@ class PipedriveV1 extends BasePipedriveIntegration
             return;
         }
 
-        try {
-            $userId = $this->getUserId();
-            if ($userId) {
-                $mapping['owner_id'] = $userId;
-            }
+        $userId = $this->getUserId();
+        if ($userId) {
+            $mapping['owner_id'] = $userId;
+        }
 
-            if ($this->personId) {
-                $mapping['person_id'] = $this->personId;
-            }
+        if ($this->personId) {
+            $mapping['person_id'] = $this->personId;
+        }
 
-            if ($this->organizationId) {
-                $mapping['organization_id'] = $this->organizationId;
-            }
+        if ($this->organizationId) {
+            $mapping['organization_id'] = $this->organizationId;
+        }
 
-            $value = new \stdClass();
-            $value->amount = $mapping['value'] ?? 0;
-            $value->currency = $mapping['currency'] ?? 'USD';
+        $value = new \stdClass();
+        $value->amount = $mapping['value'] ?? 0;
+        $value->currency = $mapping['currency'] ?? 'USD';
 
-            unset($mapping['currency']);
+        unset($mapping['currency']);
 
-            $mapping['value'] = $value->amount ? $value : null;
+        $mapping['value'] = $value->amount ? $value : null;
 
-            $note = $mapping['note'] ?? false;
-            unset($mapping['note']);
+        $note = $mapping['note'] ?? false;
+        unset($mapping['note']);
 
-            $response = $client->post(
-                $this->getEndpoint('/leads'),
-                ['json' => $mapping],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/leads'),
+            ['json' => $mapping],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_LEAD, $response);
+        $this->triggerAfterResponseEvent(self::CATEGORY_LEAD, $response);
 
-            $json = json_decode((string) $response->getBody(), false);
+        $json = json_decode((string) $response->getBody(), false);
 
-            if (isset($json->data->id)) {
-                $this->leadId = $json->data->id;
-            }
+        if (isset($json->data->id)) {
+            $this->leadId = $json->data->id;
+        }
 
-            if (!empty($note)) {
-                $json = [
-                    'content' => $note,
-                    'lead_id' => $this->leadId,
-                    'pinned_to_lead_flag' => '1',
-                ];
+        if (!empty($note)) {
+            $json = [
+                'content' => $note,
+                'lead_id' => $this->leadId,
+                'pinned_to_lead_flag' => '1',
+            ];
 
-                $this->addNote($client, $json);
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+            $this->addNote($client, $json);
         }
     }
 
@@ -355,67 +341,59 @@ class PipedriveV1 extends BasePipedriveIntegration
             return;
         }
 
-        try {
-            $userId = $this->getUserId();
-            if ($userId) {
-                $mapping['user_id'] = $userId;
-            }
+        $userId = $this->getUserId();
+        if ($userId) {
+            $mapping['user_id'] = $userId;
+        }
 
-            $stageId = $this->getStageId();
-            if ($stageId) {
-                $mapping['stage_id'] = $stageId;
-            }
+        $stageId = $this->getStageId();
+        if ($stageId) {
+            $mapping['stage_id'] = $stageId;
+        }
 
-            if ($this->personId) {
-                $mapping['person_id'] = $this->personId;
-            }
+        if ($this->personId) {
+            $mapping['person_id'] = $this->personId;
+        }
 
-            if ($this->organizationId) {
-                $mapping['org_id'] = $this->organizationId;
-            }
+        if ($this->organizationId) {
+            $mapping['org_id'] = $this->organizationId;
+        }
 
-            $note = $mapping['note'] ?? false;
-            unset($mapping['note']);
+        $note = $mapping['note'] ?? false;
+        unset($mapping['note']);
 
-            $response = $client->post(
-                $this->getEndpoint('/deals'),
-                ['json' => $mapping],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/deals'),
+            ['json' => $mapping],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_DEAL, $response);
+        $this->triggerAfterResponseEvent(self::CATEGORY_DEAL, $response);
 
-            $json = json_decode((string) $response->getBody(), false);
+        $json = json_decode((string) $response->getBody(), false);
 
-            if (isset($json->data->id)) {
-                $this->dealId = (int) $json->data->id;
-            }
+        if (isset($json->data->id)) {
+            $this->dealId = (int) $json->data->id;
+        }
 
-            if (!empty($note)) {
-                $json = [
-                    'content' => $note,
-                    'deal_id' => $this->dealId,
-                    'pinned_to_deal_flag' => '1',
-                ];
+        if (!empty($note)) {
+            $json = [
+                'content' => $note,
+                'deal_id' => $this->dealId,
+                'pinned_to_deal_flag' => '1',
+            ];
 
-                $this->addNote($client, $json);
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+            $this->addNote($client, $json);
         }
     }
 
     private function addNote(Client $client, array $json): void
     {
-        try {
-            $response = $client->post(
-                $this->getEndpoint('/notes'),
-                ['json' => $json],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/notes'),
+            ['json' => $json],
+        );
 
-            $this->triggerAfterResponseEvent('note', $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent('note', $response);
     }
 
     private function searchForDuplicate(Client $client, array $terms, string $type): ?int
@@ -434,27 +412,22 @@ class PipedriveV1 extends BasePipedriveIntegration
                     continue;
                 }
 
-                try {
-                    $response = $client->get(
-                        $this->getEndpoint('/itemSearch'),
-                        [
-                            'query' => [
-                                'term' => $term,
-                                'item_types' => $type,
-                                'fields' => $field,
-                                'exact_match' => true,
-                                'limit' => 1,
-                            ],
-                        ]
-                    );
+                $response = $client->get(
+                    $this->getEndpoint('/itemSearch'),
+                    [
+                        'query' => [
+                            'term' => $term,
+                            'item_types' => $type,
+                            'fields' => $field,
+                            'exact_match' => true,
+                            'limit' => 1,
+                        ],
+                    ]
+                );
 
-                    $json = json_decode((string) $response->getBody(), false);
-
-                    if (\count($json->data->items) > 0) {
-                        return (int) $json->data->items[0]->item->id;
-                    }
-                } catch (\Exception $exception) {
-                    $this->processException($exception, self::LOG_CATEGORY);
+                $json = json_decode((string) $response->getBody(), false);
+                if (\count($json->data->items) > 0) {
+                    return (int) $json->data->items[0]->item->id;
                 }
             }
         }

--- a/packages/plugin/src/Integrations/CRM/Salesforce/BaseSalesforceIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Salesforce/BaseSalesforceIntegration.php
@@ -97,12 +97,7 @@ abstract class BaseSalesforceIntegration extends CRMIntegration implements OAuth
 
     public function fetchFields(string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/sobjects/'.$category.'/describe'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/sobjects/'.$category.'/describe'));
         $json = json_decode((string) $response->getBody());
 
         if (!isset($json->fields) || !$json->fields) {
@@ -175,30 +170,24 @@ abstract class BaseSalesforceIntegration extends CRMIntegration implements OAuth
 
     protected function query(Client $client, string $query, array $params = []): array
     {
-        try {
-            $params = array_map([$this, 'soqlEscape'], $params);
+        $params = array_map([$this, 'soqlEscape'], $params);
+        $query = sprintf($query, ...$params);
 
-            $query = sprintf($query, ...$params);
+        $response = $client->get(
+            $this->getEndpoint('/query'),
+            [
+                'query' => [
+                    'q' => $query,
+                ],
+            ]
+        );
 
-            $response = $client->get(
-                $this->getEndpoint('/query'),
-                [
-                    'query' => [
-                        'q' => $query,
-                    ],
-                ]
-            );
-
-            $result = json_decode($response->getBody());
-
-            if (0 === $result->totalSize || !$result->done) {
-                return [];
-            }
-
-            return $result->records;
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+        $result = json_decode($response->getBody());
+        if (0 === $result->totalSize || !$result->done) {
+            return [];
         }
+
+        return $result->records;
     }
 
     protected function querySingle(Client $client, string $query, array $params = []): mixed

--- a/packages/plugin/src/Integrations/CRM/Zoho/BaseZohoIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Zoho/BaseZohoIntegration.php
@@ -113,12 +113,7 @@ abstract class BaseZohoIntegration extends CRMIntegration implements OAuth2Conne
 
     public function fetchFields(string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/settings/fields?module='.$category.'s'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/settings/fields?module='.$category.'s'));
         $json = json_decode((string) $response->getBody());
 
         if (!isset($json->fields) || !$json->fields) {
@@ -188,10 +183,14 @@ abstract class BaseZohoIntegration extends CRMIntegration implements OAuth2Conne
         $data = $response['data'][0];
 
         if ('error' === $data['status']) {
-            Freeform::getInstance()->logger->getLogger(FreeformLogger::CRM_INTEGRATION)->error(
-                self::LOG_CATEGORY.' '.$data['message'],
-                ['exception' => $data],
-            );
+            Freeform::getInstance()
+                ->logger
+                ->getLogger(FreeformLogger::CRM_INTEGRATION)
+                ->error(
+                    self::LOG_CATEGORY.' '.$data['message'],
+                    ['exception' => $data],
+                )
+            ;
 
             throw new IntegrationException($data['message']);
         }

--- a/packages/plugin/src/Integrations/EmailMarketing/CampaignMonitor/BaseCampaignMonitorIntegration.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/CampaignMonitor/BaseCampaignMonitorIntegration.php
@@ -67,11 +67,7 @@ abstract class BaseCampaignMonitorIntegration extends EmailMarketingIntegration 
     {
         $listId = $list->getResourceId();
 
-        try {
-            $response = $client->get($this->getEndpoint('/lists/'.$listId.'/customfields.json'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, $category);
-        }
+        $response = $client->get($this->getEndpoint('/lists/'.$listId.'/customfields.json'));
 
         $fieldList = [
             new FieldObject(
@@ -119,12 +115,7 @@ abstract class BaseCampaignMonitorIntegration extends EmailMarketingIntegration 
     {
         $clientId = $this->getCampaignMonitorClientId();
 
-        try {
-            $response = $client->get($this->getEndpoint('/clients/'.$clientId.'/lists.json'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/clients/'.$clientId.'/lists.json'));
         $json = json_decode((string) $response->getBody());
 
         $lists = [];

--- a/packages/plugin/src/Integrations/EmailMarketing/CampaignMonitor/Versions/CampaignMonitorV33.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/CampaignMonitor/Versions/CampaignMonitorV33.php
@@ -122,25 +122,21 @@ class CampaignMonitorV33 extends BaseCampaignMonitorIntegration
             }
         }
 
-        try {
-            $response = $client->post(
-                $this->getEndpoint('/subscribers/'.$listId.'.json'),
-                [
-                    'json' => [
-                        'EmailAddress' => $email,
-                        'Name' => $mapping['Name'] ?? '',
-                        'CustomFields' => $customFields,
-                        'Resubscribe' => true,
-                        'RestartSubscriptionBasedAutoresponders' => true,
-                        'ConsentToTrack' => 'Yes',
-                        'ConsentToSendSms' => 'Yes',
-                    ],
+        $response = $client->post(
+            $this->getEndpoint('/subscribers/'.$listId.'.json'),
+            [
+                'json' => [
+                    'EmailAddress' => $email,
+                    'Name' => $mapping['Name'] ?? '',
+                    'CustomFields' => $customFields,
+                    'Resubscribe' => true,
+                    'RestartSubscriptionBasedAutoresponders' => true,
+                    'ConsentToTrack' => 'Yes',
+                    'ConsentToSendSms' => 'Yes',
                 ],
-            );
+            ],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_CUSTOM, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_CUSTOM, $response);
     }
 }

--- a/packages/plugin/src/Integrations/EmailMarketing/ConstantContact/BaseConstantContactIntegration.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/ConstantContact/BaseConstantContactIntegration.php
@@ -41,12 +41,7 @@ abstract class BaseConstantContactIntegration extends EmailMarketingIntegration 
 
     public function fetchFields(ListObject $list, string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/contact_custom_fields'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, $category);
-        }
-
+        $response = $client->get($this->getEndpoint('/contact_custom_fields'));
         $json = json_decode((string) $response->getBody());
 
         if (!isset($json->custom_fields) || !$json->custom_fields) {
@@ -85,12 +80,7 @@ abstract class BaseConstantContactIntegration extends EmailMarketingIntegration 
 
     public function fetchLists(Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/contact_lists'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/contact_lists'));
         $json = json_decode((string) $response->getBody());
 
         $lists = [];

--- a/packages/plugin/src/Integrations/EmailMarketing/ConstantContact/Versions/ConstantContactV3.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/ConstantContact/Versions/ConstantContactV3.php
@@ -127,24 +127,20 @@ class ConstantContactV3 extends BaseConstantContactIntegration
             $contactData['street_address']['kind'] = 'home';
         }
 
-        try {
-            $contactData = array_merge(
-                [
-                    'email_address' => $email,
-                    'create_source' => 'Contact',
-                    'list_memberships' => [$listId],
-                ],
-                $contactData,
-            );
+        $contactData = array_merge(
+            [
+                'email_address' => $email,
+                'create_source' => 'Contact',
+                'list_memberships' => [$listId],
+            ],
+            $contactData,
+        );
 
-            $response = $client->post(
-                $this->getEndpoint('/contacts/sign_up_form'),
-                ['json' => $contactData],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/contacts/sign_up_form'),
+            ['json' => $contactData],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT_CUSTOM, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT_CUSTOM, $response);
     }
 }

--- a/packages/plugin/src/Integrations/EmailMarketing/Dotdigital/BaseDotdigitalIntegration.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/Dotdigital/BaseDotdigitalIntegration.php
@@ -113,12 +113,7 @@ abstract class BaseDotdigitalIntegration extends EmailMarketingIntegration imple
 
     public function fetchFields(ListObject $list, string $category, Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/data-fields'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, $category);
-        }
-
+        $response = $client->get($this->getEndpoint('/data-fields'));
         $json = json_decode((string) $response->getBody());
 
         $fieldList = [];
@@ -146,12 +141,7 @@ abstract class BaseDotdigitalIntegration extends EmailMarketingIntegration imple
 
     public function fetchLists(Client $client): array
     {
-        try {
-            $response = $client->get($this->getEndpoint('/address-books'));
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
-
+        $response = $client->get($this->getEndpoint('/address-books'));
         $json = json_decode((string) $response->getBody());
 
         $lists = [];

--- a/packages/plugin/src/Integrations/EmailMarketing/Dotdigital/Versions/DotdigitalV2.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/Dotdigital/Versions/DotdigitalV2.php
@@ -93,15 +93,11 @@ class DotdigitalV2 extends BaseDotdigitalIntegration
             ];
         }
 
-        try {
-            $response = $client->post(
-                $this->getEndpoint('/address-books/'.$listId.'/contacts'),
-                ['json' => $contactData],
-            );
+        $response = $client->post(
+            $this->getEndpoint('/address-books/'.$listId.'/contacts'),
+            ['json' => $contactData],
+        );
 
-            $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT_DATA, $response);
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
-        }
+        $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT_DATA, $response);
     }
 }

--- a/packages/plugin/src/Integrations/EmailMarketing/Mailchimp/Versions/MailchimpV3.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/Mailchimp/Versions/MailchimpV3.php
@@ -244,20 +244,16 @@ class MailchimpV3 extends BaseMailchimpIntegration
             $isComplianceState = isset($json->title) && 'member in compliance state' === strtolower($json->title);
 
             if ($is400 && $isComplianceState) {
-                try {
-                    $memberData['status'] = 'pending';
+                $memberData['status'] = 'pending';
 
-                    $response = $client->put(
-                        $this->getEndpoint('/lists/'.$listId.'/members/'.$emailHash),
-                        ['json' => $memberData],
-                    );
+                $response = $client->put(
+                    $this->getEndpoint('/lists/'.$listId.'/members/'.$emailHash),
+                    ['json' => $memberData],
+                );
 
-                    $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT, $response);
-                } catch (RequestException $exception) {
-                    $this->processException($exception, self::LOG_CATEGORY);
-                }
+                $this->triggerAfterResponseEvent(self::CATEGORY_CONTACT, $response);
             } else {
-                $this->processException($exception, self::LOG_CATEGORY);
+                throw $exception;
             }
         }
 

--- a/packages/plugin/src/Integrations/Other/Google/GoogleSheets/BaseGoogleSheetsIntegration.php
+++ b/packages/plugin/src/Integrations/Other/Google/GoogleSheets/BaseGoogleSheetsIntegration.php
@@ -28,9 +28,10 @@ use Solspace\Freeform\Library\Integrations\OAuth\OAuth2IssuedAtMilliseconds;
 use Solspace\Freeform\Library\Integrations\OAuth\OAuth2RefreshTokenInterface;
 use Solspace\Freeform\Library\Integrations\OAuth\OAuth2RefreshTokenTrait;
 use Solspace\Freeform\Library\Integrations\OAuth\OAuth2Trait;
+use Solspace\Freeform\Library\Integrations\PushableInterface;
 use Solspace\Freeform\Library\Integrations\Types\Other\GoogleSheetsIntegrationInterface;
 
-abstract class BaseGoogleSheetsIntegration extends APIIntegration implements OAuth2ConnectorInterface, OAuth2RefreshTokenInterface, OAuth2IssuedAtMilliseconds, GoogleSheetsIntegrationInterface
+abstract class BaseGoogleSheetsIntegration extends APIIntegration implements OAuth2ConnectorInterface, OAuth2RefreshTokenInterface, OAuth2IssuedAtMilliseconds, GoogleSheetsIntegrationInterface, PushableInterface
 {
     use OAuth2RefreshTokenTrait;
     use OAuth2Trait;

--- a/packages/plugin/src/Integrations/Other/Google/GoogleSheets/Versions/GoogleSheetsV4.php
+++ b/packages/plugin/src/Integrations/Other/Google/GoogleSheets/Versions/GoogleSheetsV4.php
@@ -39,15 +39,10 @@ class GoogleSheetsV4 extends BaseGoogleSheetsIntegration
         $url = $this->getEndpoint("spreadsheets/{$googleSheetsId}?fields=sheets(properties)");
 
         $names = [];
+        [, $json] = $this->getJsonResponse($client->get($url));
 
-        try {
-            [, $json] = $this->getJsonResponse($client->get($url));
-
-            foreach ($json->sheets as $sheet) {
-                $names[] = $sheet->properties->title;
-            }
-        } catch (\Exception $exception) {
-            $this->processException($exception, self::LOG_CATEGORY);
+        foreach ($json->sheets as $sheet) {
+            $names[] = $sheet->properties->title;
         }
 
         return $names;

--- a/packages/plugin/src/Integrations/Webhooks/Generic/Generic.php
+++ b/packages/plugin/src/Integrations/Webhooks/Generic/Generic.php
@@ -48,11 +48,6 @@ class Generic extends WebhookIntegration
         }
 
         $client = new Client();
-
-        try {
-            $client->post($this->getUrl(), ['json' => $json]);
-        } catch (\Exception $e) {
-            $this->processException($e, self::LOG_CATEGORY, false);
-        }
+        $client->post($this->getUrl(), ['json' => $json]);
     }
 }

--- a/packages/plugin/src/Integrations/Webhooks/Slack/Slack.php
+++ b/packages/plugin/src/Integrations/Webhooks/Slack/Slack.php
@@ -39,16 +39,16 @@ class Slack extends WebhookIntegration
         ]);
 
         if (!$message) {
-            Freeform::getInstance()->logger->getLogger(FreeformLogger::WEBHOOKS_INTEGRATION)->warning('Slack integration has no message set');
+            Freeform::getInstance()
+                ->logger
+                ->getLogger(FreeformLogger::WEBHOOKS_INTEGRATION)
+                ->warning('Slack integration has no message set')
+            ;
 
             return;
         }
 
-        try {
-            $client = new Client();
-            $client->post($this->getUrl(), ['json' => ['text' => $message]]);
-        } catch (\Exception $e) {
-            $this->processException($e, self::LOG_CATEGORY, false);
-        }
+        $client = new Client();
+        $client->post($this->getUrl(), ['json' => ['text' => $message]]);
     }
 }

--- a/packages/plugin/src/Library/Integrations/BaseIntegration.php
+++ b/packages/plugin/src/Library/Integrations/BaseIntegration.php
@@ -13,13 +13,9 @@
 namespace Solspace\Freeform\Library\Integrations;
 
 use craft\helpers\App;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Solspace\Freeform\Attributes\Integration\Type;
 use Solspace\Freeform\Events\Integrations\IntegrationResponseEvent;
-use Solspace\Freeform\Freeform;
-use Solspace\Freeform\Library\Exceptions\Integrations\IntegrationException;
-use Solspace\Freeform\Library\Logging\FreeformLogger;
 use yii\base\Event;
 
 abstract class BaseIntegration implements IntegrationInterface
@@ -101,32 +97,5 @@ abstract class BaseIntegration implements IntegrationInterface
     protected function getProcessedValue(mixed $value): null|bool|string
     {
         return App::parseEnv($value);
-    }
-
-    /**
-     * @throws \Exception
-     */
-    protected function processException(\Exception $exception, ?string $category = null, bool $throw = true): void
-    {
-        $message = $exception->getMessage();
-        if ($exception instanceof RequestException) {
-            $message = (string) $exception->getResponse()->getBody();
-        }
-
-        Freeform::getInstance()
-            ->logger
-            ->getLogger(FreeformLogger::INTEGRATION)
-            ->error(
-                $category.': '.$message,
-                ['integration' => [
-                    'id' => $this->getId(),
-                    'handle' => $this->getHandle(),
-                ]],
-            )
-        ;
-
-        if ($throw) {
-            throw new IntegrationException($exception->getMessage(), $exception->getCode(), $exception);
-        }
     }
 }

--- a/packages/plugin/src/Library/Integrations/IntegrationInterface.php
+++ b/packages/plugin/src/Library/Integrations/IntegrationInterface.php
@@ -17,6 +17,7 @@ use Solspace\Freeform\Attributes\Integration\Type;
 interface IntegrationInterface
 {
     public const EVENT_AFTER_RESPONSE = 'after-response';
+    public const EVENT_ON_FAILED_REQUEST = 'on-failed-request';
 
     public const FLAG_GLOBAL_PROPERTY = 'global-property';
     public const FLAG_AS_HIDDEN_IN_INSTANCE = 'as-hidden-in-instance';

--- a/packages/plugin/src/Library/Integrations/PushableInterface.php
+++ b/packages/plugin/src/Library/Integrations/PushableInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Solspace\Freeform\Library\Integrations;
+
+use GuzzleHttp\Client;
+use Solspace\Freeform\Form\Form;
+
+interface PushableInterface
+{
+    /**
+     * Push objects to the CRM.
+     */
+    public function push(Form $form, Client $client): void;
+}

--- a/packages/plugin/src/Library/Integrations/Types/CRM/CRMIntegrationInterface.php
+++ b/packages/plugin/src/Library/Integrations/Types/CRM/CRMIntegrationInterface.php
@@ -13,17 +13,12 @@
 namespace Solspace\Freeform\Library\Integrations\Types\CRM;
 
 use GuzzleHttp\Client;
-use Solspace\Freeform\Form\Form;
 use Solspace\Freeform\Library\Integrations\APIIntegrationInterface;
+use Solspace\Freeform\Library\Integrations\PushableInterface;
 
-interface CRMIntegrationInterface extends APIIntegrationInterface
+interface CRMIntegrationInterface extends APIIntegrationInterface, PushableInterface
 {
     public const EVENT_ON_PUSH = 'on-push';
-
-    /**
-     * Push objects to the CRM.
-     */
-    public function push(Form $form, Client $client): bool;
 
     public function fetchFields(string $category, Client $client): array;
 }

--- a/packages/plugin/src/Library/Integrations/Types/EmailMarketing/EmailMarketingIntegrationInterface.php
+++ b/packages/plugin/src/Library/Integrations/Types/EmailMarketing/EmailMarketingIntegrationInterface.php
@@ -13,15 +13,13 @@
 namespace Solspace\Freeform\Library\Integrations\Types\EmailMarketing;
 
 use GuzzleHttp\Client;
-use Solspace\Freeform\Form\Form;
 use Solspace\Freeform\Library\Integrations\IntegrationInterface;
+use Solspace\Freeform\Library\Integrations\PushableInterface;
 use Solspace\Freeform\Library\Integrations\Types\EmailMarketing\DataObjects\ListObject;
 
-interface EmailMarketingIntegrationInterface extends IntegrationInterface
+interface EmailMarketingIntegrationInterface extends IntegrationInterface, PushableInterface
 {
     public static function isInstallable(): bool;
-
-    public function push(Form $form, Client $client): void;
 
     public function fetchLists(Client $client): array;
 


### PR DESCRIPTION
### Related Ticket Number
[SFT-1310](https://solspace.atlassian.net/browse/SFT-1310)
#1412

### Description
A client reports that his ZOHO integration returns an `invalid_token` error, and based on the logs it seems it happens every hour, which is the lifespan of the `access_token`. For some reason his token does not get refreshed in a timely manner. A failsafe for this is added in this PR, which performs a token refresh flow once if an access token returns an unauthorized response.

- refactor failed response catching flow
- add a logger on failed exceptions through an event, rather than manually
- attach token refresh flow on `401` responses on refresh token capable integrations


[SFT-1310]: https://solspace.atlassian.net/browse/SFT-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ