### PR TITLE
[SFT-1386]: SQL Error on some  MySQL installs when creating content tables

### DIFF
--- a/packages/plugin/src/Form/Managers/ContentManager.php
+++ b/packages/plugin/src/Form/Managers/ContentManager.php
@@ -56,17 +56,15 @@ class ContentManager
         $db->createCommand()
             ->createTable(
                 $tableName,
-                ['id' => $schema->createColumnSchemaBuilder(Schema::TYPE_INTEGER)]
+                [
+                    'id' => $schema
+                        ->createColumnSchemaBuilder(Schema::TYPE_INTEGER)
+                        ->notNull()
+                        ->append('PRIMARY KEY'),
+                ]
             )
             ->execute()
         ;
-
-        if (!$db->getIsPgsql()) {
-            $db->createCommand()
-                ->addPrimaryKey('PK', $tableName, ['id'])
-                ->execute()
-            ;
-        }
 
         $db->createCommand()
             ->addForeignKey(


### PR DESCRIPTION
### Description

When a content table was being created before, it was created with `id` as a simple `int` column, then it was set as a `primary key` and then a constraint was added for the submissions table.

This caused an issue on some installs where a primary key column is mandatory and one was created and set as invisible. This caused a conflict when the `id` column was being set as primary, since one was there already.