### PR TITLE
fix(SFT-1540): convert extended ASCII characters in form or field handles

### DIFF
--- a/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
+++ b/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
@@ -235,6 +235,8 @@ class m230101_200000_FF4to5_MigrateData extends Migration
 
         $label = $data->label ?? '';
         $handle = $data->handle ?? $data->type.'_'.HashHelper::sha1(random_bytes(10).microtime(), 5);
+        $handle = preg_replace('/\ /', '_', $handle);
+        $handle = StringHelper::toHandle($handle);
 
         if (!$label) {
             $globalField = $this->globalFieldData[$data->id ?? 0] ?? null;


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/1610

In earlier versions of Craft, users could create form or field handles using extended ASCII characters.

This PR converts any extended ASCII characters found in form or field handles when migrating to v5 to realign with Craft v4 and v5 `handle` rules.

I created a test form called `Armbånd Test` with handle `ArmbåndTest` with ID 1.
I created a test field called `Armbånd Test` with handle `Armbånd Test`.
I renamed the related submissions table to `craft_freeform_submissions_armbåndtest_1`.

After migrations ran, the results are as follows:

Form handle renamed to `armbandtest`, including handle value stored in metadata column.
Field handle renamed to `armbandtest` and value stored in metadata column.
Related submissions table renamed to `craft_freeform_submissions_armbandtest_1`.

I will drop test DB dump in Slack.