### PR TITLE
fix(SFT-1594): correctly fetch the correct fields based on the category for Pipedrive integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Fixed a bug where Matrix relation titles would not always display correctly in the **Usage in Elements** tab. Set `Entry ID#` as a title fallback for Matrix relations without a title.
+- Fixed a bug where the Pipedrive integration was not correctly mapping to Lead fields.
 - Fixed a bug where required field validation wasn't working correctly when using `is one of` and `is not one of` conditional rules logic on it.
 - Fixed a bug where the Freeform 4.x migration could fail if a form name was too long.
 - Fixed a bug where the Stripe payment status was not updating for previously declined cards.

--- a/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
@@ -89,7 +89,11 @@ abstract class BasePipedriveIntegration extends CRMIntegration implements OAuth2
 
     public function fetchFields(string $category, Client $client): array
     {
-        $response = $client->get($this->getEndpoint('/'.strtolower($category).'Fields'));
+        $segment = (self::CATEGORY_LEAD === $category)
+            ? '/dealFields'
+            : '/'.strtolower($category).'Fields';
+
+        $response = $client->get($this->getEndpoint($segment));
         $json = json_decode((string) $response->getBody());
 
         if (!isset($json->success) || !$json->success) {

--- a/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/Pipedrive/BasePipedriveIntegration.php
@@ -89,9 +89,11 @@ abstract class BasePipedriveIntegration extends CRMIntegration implements OAuth2
 
     public function fetchFields(string $category, Client $client): array
     {
-        $segment = (self::CATEGORY_LEAD === $category)
-            ? '/dealFields'
-            : '/'.strtolower($category).'Fields';
+        $segment = match ($category) {
+            self::CATEGORY_PERSON => '/personFields',
+            self::CATEGORY_ORGANIZATION => '/organizationFields',
+            self::CATEGORY_LEAD, self::CATEGORY_DEAL => '/dealFields',
+        };
 
         $response = $client->get($this->getEndpoint($segment));
         $json = json_decode((string) $response->getBody());

--- a/packages/plugin/src/Integrations/CRM/Pipedrive/Versions/PipedriveV1.php
+++ b/packages/plugin/src/Integrations/CRM/Pipedrive/Versions/PipedriveV1.php
@@ -55,7 +55,7 @@ class PipedriveV1 extends BasePipedriveIntegration
     #[Input\Special\Properties\FieldMapping(
         instructions: 'Select the Freeform fields to be mapped to the applicable Pipedrive Lead fields',
         order: 4,
-        source: 'api/integrations/crm/fields/'.self::CATEGORY_DEAL,
+        source: 'api/integrations/crm/fields/'.self::CATEGORY_LEAD,
         parameterFields: ['id' => 'id'],
     )]
     protected ?FieldMapping $leadMapping = null;


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/1596

I'm a little unsure how this previously worked. I know Leads uses `dealFields` endpoint but since we refactored this integration, lead fields were saved under Deal category in the DB. Now Pipedrive or API Integration base class is passing in Deal as category for Leads when fetching fields and therefore not finding any fields, throwing a generic "out of scope" error.

I feel like the API has slightly changed.