### PR TITLE
fix(SFT-1621): form submission table names being incorrectly converted to camel case during migration

### DIFF
--- a/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
+++ b/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
@@ -70,9 +70,9 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
                 $attributes[$attr] = $value;
             }
 
-            $formHandle = preg_replace('/\ /', '_', $form->handle);
-            $formHandle = StringHelper::toHandle($formHandle);
+            $formHandle = StringHelper::toAscii($form->handle);
             $formHandle = StringHelper::truncate($formHandle, $maxHandleSize, '');
+            $formHandle = trim($formHandle, '-_');
 
             $propertyProvider->setObjectProperties(
                 $general,
@@ -152,12 +152,13 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
             $formId = $matches[2];
 
             $formHandle = $forms[$formId] ?? null;
-            $formHandle = StringHelper::toSnakeCase($formHandle);
-            $formHandle = StringHelper::truncate($formHandle, $maxHandleSize, '');
-            $formHandle = trim($formHandle, '-_');
             if (!$formHandle) {
                 continue;
             }
+
+            $formHandle = StringHelper::toSnakeCase($formHandle);
+            $formHandle = StringHelper::truncate($formHandle, $maxHandleSize, '');
+            $formHandle = trim($formHandle, '-_');
 
             $tempTableName = 'tmp_'.substr(sha1($tableName), 0, 5);
 

--- a/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
+++ b/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
@@ -139,6 +139,8 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
         ;
 
         $prefix = \Craft::$app->db->tablePrefix;
+        $prefixLength = \strlen($prefix);
+        $maxHandleSize = 36 - $prefixLength;
 
         $tables = $this->db->schema->getTableSchemas();
         foreach ($tables as $table) {
@@ -150,6 +152,9 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
             $formId = $matches[2];
 
             $formHandle = $forms[$formId] ?? null;
+            $formHandle = StringHelper::toSnakeCase($formHandle);
+            $formHandle = StringHelper::truncate($formHandle, $maxHandleSize, '');
+            $formHandle = trim($formHandle, '-_');
             if (!$formHandle) {
                 continue;
             }

--- a/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
+++ b/packages/plugin/src/migrations/m230101_200000_FF4to5_MigrateData.php
@@ -235,8 +235,7 @@ class m230101_200000_FF4to5_MigrateData extends Migration
 
         $label = $data->label ?? '';
         $handle = $data->handle ?? $data->type.'_'.HashHelper::sha1(random_bytes(10).microtime(), 5);
-        $handle = preg_replace('/\ /', '_', $handle);
-        $handle = StringHelper::toHandle($handle);
+        $handle = StringHelper::toAscii($handle);
 
         if (!$label) {
             $globalField = $this->globalFieldData[$data->id ?? 0] ?? null;


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/1648

- `My Test Form` --> `myTestForm`
- `My Super Long Disgusting Gross Filthy Form Handle Name And Stuff Hello` -->  `mySuperLongDisgustingGrossFilthyFormHandleNameAndStuffHello`
- `Covid 19 Test` -->  `covid19test`
- `Dash Form` --> `dash-form`
- `Under Score Form` --> `under_score_form`
- `Long Form Name with Super Gross mix of numbers and characters and such` --> `longFormNameWithSuperGross69MixOfNumbersAndCharactersAndSuch`
- `COVID19` --> `covid19`