### PR TITLE
Bundle loader crashing if a cached class is found in the class map

### DIFF
--- a/packages/plugin/src/Bundles/Integrations/Providers/IntegrationTypeProvider.php
+++ b/packages/plugin/src/Bundles/Integrations/Providers/IntegrationTypeProvider.php
@@ -15,7 +15,12 @@ class IntegrationTypeProvider
     public function getTypeDefinition(string $integrationClass): ?Type
     {
         if (!isset(self::$types[$integrationClass])) {
-            $reflectionClass = new \ReflectionClass($integrationClass);
+            try {
+                $reflectionClass = new \ReflectionClass($integrationClass);
+            } catch (\ReflectionException) {
+                return null;
+            }
+
             if (!$reflectionClass->implementsInterface(IntegrationInterface::class)) {
                 return null;
             }

--- a/packages/plugin/src/Library/Bundles/BundleLoader.php
+++ b/packages/plugin/src/Library/Bundles/BundleLoader.php
@@ -21,19 +21,23 @@ class BundleLoader
         $loadableClasses = [];
 
         /** @var BundleInterface $class */
-        foreach ($classMap as $class => $path) {
-            $reflectionClass = new \ReflectionClass($class);
-            if (
-                $reflectionClass->implementsInterface(BundleInterface::class)
-                && !$reflectionClass->isAbstract()
-                && !$reflectionClass->isInterface()
-            ) {
-                if ($class::isProOnly() && !Freeform::getInstance()->isPro()) {
-                    continue;
-                }
+        foreach ($classMap as $class => $classPath) {
+            try {
+                $reflectionClass = new \ReflectionClass($class);
+                if (
+                    $reflectionClass->implementsInterface(BundleInterface::class)
+                    && !$reflectionClass->isAbstract()
+                    && !$reflectionClass->isInterface()
+                ) {
+                    if ($class::isProOnly() && !Freeform::getInstance()->isPro()) {
+                        continue;
+                    }
 
-                $priority = $class::getPriority();
-                $loadableClasses[$priority][] = $class;
+                    $priority = $class::getPriority();
+                    $loadableClasses[$priority][] = $class;
+                }
+            } catch (\ReflectionException) {
+                continue;
             }
         }
 


### PR DESCRIPTION
* adding `try/catch` blocks for reflections, since there are times when some classes are removed, but the cache still thinks they're there