### PR TITLE
fix(SFT-2149): reverted changes that removed a required subquery on submissions query

### DIFF
--- a/packages/plugin/src/Elements/Db/SubmissionQuery.php
+++ b/packages/plugin/src/Elements/Db/SubmissionQuery.php
@@ -183,6 +183,7 @@ class SubmissionQuery extends ElementQuery
                 $contentTable = Submission::getContentTableName($form);
 
                 $this->query->leftJoin("{$contentTable} fc{$formId}", "[[fc{$formId}]].[[id]] = [[{$table}]].[[id]]");
+                $this->subQuery->leftJoin("{$contentTable} fc{$formId}", "[[fc{$formId}]].[[id]] = [[{$table}]].[[id]]");
 
                 $storableFields = $form->getLayout()->getFields()->getExcludedList(NoStorageInterface::class);
                 foreach ($storableFields as $field) {


### PR DESCRIPTION
Reverts changes made in PR #2012 that turns out we actually need.