### PR TITLE
fix(SFT-2241): strengthen locking in digest service and prevent duplicate digest jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "solspace/craft-freeform",
   "description": "The most flexible and user-friendly form building plugin!",
-  "version": "5.11.7",
+  "version": "5.11.7.2",
   "type": "craft-plugin",
   "authors": [
     {
@@ -53,7 +53,7 @@
     "post-update-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility"
   },
   "extra": {
-    "schemaVersion": "5.6.3",
+    "schemaVersion": "5.6.4",
     "handle": "freeform",
     "class": "Solspace\\Freeform\\Freeform",
     "name": "Freeform",

--- a/packages/plugin/src/Bundles/Digest/DigestBundle.php
+++ b/packages/plugin/src/Bundles/Digest/DigestBundle.php
@@ -5,17 +5,19 @@ namespace Solspace\Freeform\Bundles\Digest;
 use Carbon\Carbon;
 use craft\helpers\Queue;
 use craft\web\Application;
-use Solspace\Freeform\Bundles\Digest\Providers\DigestLoggerProvider;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Jobs\SendDigestJob;
 use Solspace\Freeform\Library\Bundles\FeatureBundle;
 use Solspace\Freeform\Records\FeedRecord;
-use Solspace\Freeform\Services\Pro\DigestService;
 use yii\base\Event;
 
 class DigestBundle extends FeatureBundle
 {
-    public function __construct(private DigestLoggerProvider $loggerProvider)
+    public const CACHE_KEY_DIGEST = 'freeform-digest-bundle-queued';
+
+    public const CACHE_TTL_DIGEST = 60 * 60; // every 1h
+
+    public function __construct()
     {
         if (!$this->plugin()->isInstalled || \Craft::$app->request->getIsConsoleRequest()) {
             return;
@@ -34,11 +36,9 @@ class DigestBundle extends FeatureBundle
             return;
         }
 
-        if (Freeform::isLockedWithGuard(DigestService::CACHE_KEY_DIGEST, DigestService::LOCK_KEY_DIGEST, DigestService::CACHE_TTL_DIGEST)) {
+        if (Freeform::isLocked(self::CACHE_KEY_DIGEST, self::CACHE_TTL_DIGEST)) {
             return;
         }
-
-        $this->loggerProvider->getLogger()->info('DigestBundle triggerDigest - Started processing');
 
         $settings = $this->plugin()->settings;
 
@@ -46,23 +46,10 @@ class DigestBundle extends FeatureBundle
         $clientRecipients = $settings->getClientDigestRecipients();
 
         if (!$devRecipients->count() && !$clientRecipients->count()) {
-            $this->loggerProvider->getLogger()->info('DigestBundle triggerDigest - Skipped - No recipients', [
-                'devRecipients' => $devRecipients->emailsToArray(),
-                'clientRecipients' => $clientRecipients->emailsToArray(),
-            ]);
-
             return;
         }
 
-        $this->loggerProvider->getLogger()->info('DigestBundle triggerDigest - Adding job to queue', [
-            'devRecipients' => $devRecipients->emailsToArray(),
-            'clientRecipients' => $clientRecipients->emailsToArray(),
-        ]);
-
         $job = new SendDigestJob(new Carbon('now'));
         Queue::push($job, $settings->getQueuePriority());
-
-        $this->loggerProvider->getLogger()->info('DigestBundle triggerDigest - Job added to queue');
-        $this->loggerProvider->getLogger()->info('DigestBundle triggerDigest - Finished processing');
     }
 }

--- a/packages/plugin/src/Bundles/GarbageCollection/PurgeNotificationLogs.php
+++ b/packages/plugin/src/Bundles/GarbageCollection/PurgeNotificationLogs.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solspace\Freeform\Bundles\GarbageCollection;
+
+use Solspace\Freeform\Freeform;
+use Solspace\Freeform\Jobs\FreeformQueueHandler;
+use Solspace\Freeform\Jobs\PurgeNotificationLogsJob;
+use Solspace\Freeform\Library\Bundles\FeatureBundle;
+use yii\base\Application;
+use yii\base\Event;
+
+class PurgeNotificationLogs extends FeatureBundle
+{
+    private const CACHE_KEY = 'freeform-purge-notification-logs';
+    private const CACHE_TTL = 60 * 60; // 1h
+
+    public function __construct(private FreeformQueueHandler $queueHandler)
+    {
+        if (\Craft::$app->request->isConsoleRequest) {
+            return;
+        }
+
+        Event::on(
+            Application::class,
+            Application::EVENT_AFTER_REQUEST,
+            [$this, 'removeNotificationLogs']
+        );
+    }
+
+    public function removeNotificationLogs(): void
+    {
+        if (!Freeform::getInstance()->isPro()) {
+            return;
+        }
+
+        if (Freeform::isLocked(self::CACHE_KEY, self::CACHE_TTL)) {
+            return;
+        }
+
+        $this->queueHandler->queueSingleJobInstance(new PurgeNotificationLogsJob());
+    }
+}

--- a/packages/plugin/src/Commands/PurgeController.php
+++ b/packages/plugin/src/Commands/PurgeController.php
@@ -106,6 +106,16 @@ class PurgeController extends Controller
         return ExitCode::OK;
     }
 
+    public function actionNotificationLogs(): int
+    {
+        $string = $this->ansiFormat('days old...', Console::FG_BLUE);
+        $this->stdout("Purging notification logs which are at least 8 {$string}\n\n", Console::FG_BLUE);
+
+        Freeform::getInstance()->digest->purgeNotificationLogs();
+
+        return ExitCode::OK;
+    }
+
     private function echoSubmissionCount(int $count)
     {
         $count = $this->ansiFormat($count, Console::FG_YELLOW);

--- a/packages/plugin/src/Jobs/PurgeNotificationLogsJob.php
+++ b/packages/plugin/src/Jobs/PurgeNotificationLogsJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Solspace\Freeform\Jobs;
+
+use craft\queue\BaseJob;
+use Solspace\Freeform\Freeform;
+
+class PurgeNotificationLogsJob extends BaseJob
+{
+    public function execute($queue): void
+    {
+        Freeform::getInstance()->digest->purgeNotificationLogs();
+    }
+
+    protected function defaultDescription(): ?string
+    {
+        return 'Freeform: Purging Old Notification Logs';
+    }
+}

--- a/packages/plugin/src/Jobs/SendDigestJob.php
+++ b/packages/plugin/src/Jobs/SendDigestJob.php
@@ -8,6 +8,8 @@ use Solspace\Freeform\Freeform;
 
 class SendDigestJob extends BaseJob
 {
+    public $unique = true;
+
     public function __construct(public Carbon $refDate)
     {
         parent::__construct();
@@ -15,10 +17,31 @@ class SendDigestJob extends BaseJob
 
     public function execute($queue): void
     {
-        $freeform = Freeform::getInstance();
+        try {
+            $freeform = Freeform::getInstance();
 
-        $freeform->feed->fetchFeed();
-        $freeform->digest->triggerDigest($this->refDate);
+            $freeform->feed->fetchFeed();
+            $freeform->digest->triggerDigest($this->refDate);
+        } catch (\Throwable $exception) {
+            \Craft::error('SendDigestJob execute - Failed: '.$exception->getMessage(), __METHOD__);
+
+            throw $exception;
+        }
+    }
+
+    public function getTtr(): int
+    {
+        return 300; // time to reserve (seconds)
+    }
+
+    public function canRetry($attempt, $error): bool
+    {
+        return false;
+    }
+
+    public function getUniqueId(): string
+    {
+        return 'send-digest-job-'.$this->refDate->format('Y-m-d');
     }
 
     protected function defaultDescription(): ?string

--- a/packages/plugin/src/Records/NotificationLogRecord.php
+++ b/packages/plugin/src/Records/NotificationLogRecord.php
@@ -18,9 +18,10 @@ use craft\db\ActiveRecord;
 /**
  * Class Freeform_NotificationRecord.
  *
- * @property int    $id
- * @property string $type
- * @property string $name
+ * @property int       $id
+ * @property string    $type
+ * @property \DateTime $digestDate
+ * @property string    $name
  */
 class NotificationLogRecord extends ActiveRecord
 {
@@ -32,5 +33,13 @@ class NotificationLogRecord extends ActiveRecord
     public static function tableName(): string
     {
         return self::TABLE;
+    }
+
+    public function rules(): array
+    {
+        return [
+            [['type', 'digestDate'], 'required'],
+            ['digestDate', 'date', 'format' => 'php:Y-m-d'],
+        ];
     }
 }

--- a/packages/plugin/src/Services/FreeformFeedService.php
+++ b/packages/plugin/src/Services/FreeformFeedService.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use craft\db\Query;
 use craft\helpers\App;
 use GuzzleHttp\Client;
-use Solspace\Freeform\Bundles\Digest\Providers\DigestLoggerProvider;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\DataObjects\FreeformFeed\FeedItem;
 use Solspace\Freeform\Library\DataObjects\Summary\InstallSummary;
@@ -22,7 +21,7 @@ class FreeformFeedService extends Component
     public const CACHE_KEY_FEED = 'freeform-feed-cache-key';
     public const CACHE_TTL_FEED = 60 * 60 * 5; // every 5 hours
 
-    public function __construct(private DigestLoggerProvider $loggerProvider)
+    public function __construct()
     {
         parent::__construct();
     }
@@ -85,7 +84,7 @@ class FreeformFeedService extends Component
 
     public function fetchFeed(): void
     {
-        if (Freeform::isLockedWithGuard(self::CACHE_KEY_FEED, self::LOCK_KEY_FEED, self::CACHE_TTL_FEED)) {
+        if (!\Craft::$app->db->tableExists(FeedRecord::TABLE)) {
             return;
         }
 
@@ -93,21 +92,15 @@ class FreeformFeedService extends Component
             return;
         }
 
-        if (!\Craft::$app->db->tableExists(FeedRecord::TABLE)) {
+        if (Freeform::isLockedWithGuard(self::CACHE_KEY_FEED, self::LOCK_KEY_FEED, self::CACHE_TTL_FEED)) {
             return;
         }
 
-        $this->loggerProvider->getLogger()->info('FreeformFeedService fetchFeed - Started processing');
-
         $this->parseFeed();
-
-        $this->loggerProvider->getLogger()->info('FreeformFeedService fetchFeed - Finished processing');
     }
 
     public function parseFeed(): void
     {
-        $this->loggerProvider->getLogger()->info('FreeformFeedService parseFeed - Started processing');
-
         $currentVersion = Freeform::getInstance()->getVersion();
         $feed = $this->getFeed();
 
@@ -155,8 +148,6 @@ class FreeformFeedService extends Component
 
             $record->save();
 
-            $this->loggerProvider->getLogger()->info('FreeformFeedService parseFeed - Created new feed record');
-
             if ($record->max && version_compare($currentVersion, $record->max, '>')) {
                 continue;
             }
@@ -197,12 +188,8 @@ class FreeformFeedService extends Component
                 $notificationRecord->seen = false;
                 $notificationRecord->issueDate = $record->issueDate;
                 $notificationRecord->save();
-
-                $this->loggerProvider->getLogger()->info('FreeformFeedService parseFeed - Created new feed notification record');
             }
         }
-
-        $this->loggerProvider->getLogger()->info('FreeformFeedService parseFeed - Finished processing');
     }
 
     /**

--- a/packages/plugin/src/Services/Pro/DigestService.php
+++ b/packages/plugin/src/Services/Pro/DigestService.php
@@ -41,6 +41,11 @@ class DigestService extends Component
             return;
         }
 
+        // Exit early if digestDate column is missing
+        if (!\Craft::$app->db->getTableSchema('{{%freeform_notification_log}}')?->getColumn('digestDate')) {
+            return;
+        }
+
         if (Freeform::isLockedWithGuard(self::CACHE_KEY_DIGEST, self::LOCK_KEY_DIGEST, self::CACHE_TTL_DIGEST)) {
             return;
         }
@@ -57,17 +62,18 @@ class DigestService extends Component
         $isProduction = 'production' === strtolower(\Craft::$app->getConfig()->env);
         if (!$isProduction && $settingsService->isDigestOnlyOnProduction()) {
             $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Skipped - Digest only allowed on Production');
+            $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished processing');
 
             return;
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Started digest processing');
+        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest - Started processing');
 
         $devRecipients = $settingsService->getDigestRecipients();
         $devFrequency = $settingsService->getDigestFrequency();
 
         if ($devRecipients->count()) {
-            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - Found digest recipients', [
+            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - digest - Found recipients', [
                 'recipients' => $devRecipients->emailsToArray(),
                 'frequency' => $devFrequency,
             ]);
@@ -80,14 +86,14 @@ class DigestService extends Component
             );
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished digest processing');
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Started digest-client processing');
+        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest - Finished processing');
+        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest-client - Started processing');
 
         $clientRecipients = $settingsService->getClientDigestRecipients();
         $clientFrequency = $settingsService->getClientDigestFrequency();
 
         if ($clientRecipients->count()) {
-            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - Found digest-client recipients', [
+            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - digest-client - Found recipients', [
                 'recipients' => $clientRecipients->emailsToArray(),
                 'frequency' => $clientFrequency,
             ]);
@@ -100,7 +106,7 @@ class DigestService extends Component
             );
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished digest-client processing');
+        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest-client - Finished processing');
         $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished processing');
     }
 
@@ -150,9 +156,16 @@ class DigestService extends Component
             return;
         }
 
+        $column = 'digestDate';
+
+        // Only run if the column exists
+        if (!\Craft::$app->db->getTableSchema('{{%freeform_notification_log}}')?->getColumn($column)) {
+            return;
+        }
+
         $cutoff = (new \DateTime())->modify('-8 days')->format('Y-m-d');
 
-        NotificationLogRecord::deleteAll(['<', 'digestDate', $cutoff]);
+        NotificationLogRecord::deleteAll(['<', $column, $cutoff]);
     }
 
     private function parseDigest(string $type, RecipientCollection $recipients, int $frequency, Carbon $refDate): void
@@ -161,15 +174,16 @@ class DigestService extends Component
 
         if (empty($recipients->emailsToArray())) {
             $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Recipients not found");
+            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
 
         $lookupStart = $refDate->clone()->startOfDay();
-        $lookupEnd = $refDate->copy()->endOfDay();
 
         if (-1 !== $frequency && $lookupStart->dayOfWeek !== $frequency) {
             $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Frequency mismatch");
+            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
@@ -184,6 +198,7 @@ class DigestService extends Component
 
         if ($exists) {
             $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Already sent for {$lookupStart->toDateString()}");
+            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
@@ -221,6 +236,7 @@ class DigestService extends Component
             if (str_contains($exception->getMessage(), 'UNIQUE') || str_contains($exception->getMessage(), 'duplicate')) {
                 // Someone else already sent it
                 $this->loggerProvider->getLogger()->warning("DigestService parseDigest - {$type} - Skipped - Already sent (duplicate record)");
+                $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
 
                 return;
             }

--- a/packages/plugin/src/Services/Pro/DigestService.php
+++ b/packages/plugin/src/Services/Pro/DigestService.php
@@ -3,13 +3,13 @@
 namespace Solspace\Freeform\Services\Pro;
 
 use Carbon\Carbon;
-use craft\helpers\Db;
 use craft\web\View;
 use Solspace\Freeform\Bundles\Digest\Providers\DigestLoggerProvider;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\DataObjects\NotificationTemplate;
 use Solspace\Freeform\Notifications\Components\Recipients\RecipientCollection;
 use Solspace\Freeform\Records\FeedMessageRecord;
+use Solspace\Freeform\Records\FeedRecord;
 use Solspace\Freeform\Records\NotificationLogRecord;
 use yii\base\Component;
 
@@ -37,11 +37,19 @@ class DigestService extends Component
 
     public function triggerDigest(Carbon $refDate): void
     {
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Started processing');
+        if (!\Craft::$app->db->tableExists(FeedRecord::TABLE)) {
+            return;
+        }
+
+        if (Freeform::isLockedWithGuard(self::CACHE_KEY_DIGEST, self::LOCK_KEY_DIGEST, self::CACHE_TTL_DIGEST)) {
+            return;
+        }
 
         if (Freeform::getInstance()->edition()->isBelow(Freeform::EDITION_LITE)) {
             return;
         }
+
+        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Started processing');
 
         $freeform = Freeform::getInstance();
         $settingsService = $freeform->settings;
@@ -136,6 +144,17 @@ class DigestService extends Component
         $this->loggerProvider->getLogger()->info("DigestService sendDigest - {$type} - Finished processing");
     }
 
+    public function purgeNotificationLogs(): void
+    {
+        if (!Freeform::getInstance()->isPro()) {
+            return;
+        }
+
+        $cutoff = (new \DateTime())->modify('-8 days')->format('Y-m-d');
+
+        NotificationLogRecord::deleteAll(['<', 'digestDate', $cutoff]);
+    }
+
     private function parseDigest(string $type, RecipientCollection $recipients, int $frequency, Carbon $refDate): void
     {
         $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Started processing");
@@ -155,24 +174,24 @@ class DigestService extends Component
             return;
         }
 
-        $record = NotificationLogRecord::find()
-            ->where(Db::parseDateParam('dateCreated', $lookupStart, '>='))
-            ->andWhere(Db::parseDateParam('dateCreated', $lookupEnd, '<='))
-            ->andWhere(['type' => $type])
-            ->one()
+        $exists = NotificationLogRecord::find()
+            ->where([
+                'type' => $type,
+                'digestDate' => $lookupStart->toDateString(),
+            ])
+            ->exists()
         ;
 
-        if ($record) {
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Notification Log Record already exists");
+        if ($exists) {
+            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Already sent for {$lookupStart->toDateString()}");
 
             return;
         }
 
-        if (-1 === $frequency) {
-            $rangeStart = $lookupStart->copy()->subDay();
-        } else {
-            $rangeStart = $lookupStart->copy()->subWeek();
-        }
+        // Time range for actual digest data
+        $rangeStart = (-1 === $frequency)
+            ? $lookupStart->copy()->subDay()
+            : $lookupStart->copy()->subWeek();
 
         $rangeEnd = $lookupStart->copy()->subDay()->endOfDay();
 
@@ -181,13 +200,37 @@ class DigestService extends Component
             'rangeEnd' => $rangeEnd,
         ]);
 
-        $this->sendDigest($recipients, $type, $rangeStart, $rangeEnd);
+        $db = \Craft::$app->getDb();
+        $transaction = $db->beginTransaction();
 
-        $record = new NotificationLogRecord();
-        $record->type = $type;
-        $record->save();
+        try {
+            // Try to write log record to block duplicates
+            $record = new NotificationLogRecord();
+            $record->type = $type;
+            $record->digestDate = $lookupStart->toDateString(); // e.g. '2025-07-24'
+            $record->save(false); // skip validation
 
-        $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Notification Log Record created");
+            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Notification log record created");
+
+            $this->sendDigest($recipients, $type, $rangeStart, $rangeEnd);
+
+            $transaction->commit();
+        } catch (\Throwable $exception) {
+            $transaction->rollBack();
+
+            if (str_contains($exception->getMessage(), 'UNIQUE') || str_contains($exception->getMessage(), 'duplicate')) {
+                // Someone else already sent it
+                $this->loggerProvider->getLogger()->warning("DigestService parseDigest - {$type} - Skipped - Already sent (duplicate record)");
+
+                return;
+            }
+
+            $this->loggerProvider->getLogger()->error("DigestService parseDigest - {$type} - Failed: {$exception->getMessage()}");
+
+            // Re-throw so the queue knows it failed
+            throw $exception;
+        }
+
         $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
     }
 

--- a/packages/plugin/src/migrations/Install.php
+++ b/packages/plugin/src/migrations/Install.php
@@ -321,6 +321,7 @@ class Install extends StreamlinedInstallMigration
             (new Table('freeform_notification_log'))
                 ->addField('id', $this->primaryKey())
                 ->addField('type', $this->string(30)->notNull())
+                ->addField('digestDate', $this->date()->null()->defaultValue(null))
                 ->addField('name', $this->string())
                 ->addIndex(['type', 'dateCreated']),
 

--- a/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
+++ b/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
@@ -3,6 +3,7 @@
 namespace Solspace\Freeform\migrations;
 
 use craft\db\Migration;
+use craft\db\Query;
 use yii\db\Expression;
 
 class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
@@ -13,6 +14,13 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
         $table = '{{%freeform_notification_log}}';
         $indexName = 'freeform_notification_log_type_digestDate_unique_idx';
 
+        // Determine correct casting expression based on DB driver
+        $driver = \Craft::$app->getDb()->getDriverName();
+        $castDateExpr = 'pgsql' === $driver
+            ? 'CAST("dateCreated" AS DATE)'
+            : 'CAST(`dateCreated` AS DATE)';
+        $alias = 'pgsql' === $driver ? '"digestDate"' : 'digestDate';
+
         // Add `digestDate` column if it doesn't exist
         if (!$this->db->getTableSchema($table)->getColumn($column)) {
             $this->addColumn($table, $column, $this->date()->after('type')->null()->defaultValue(null));
@@ -20,19 +28,49 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
 
         // Populate digestDate from dateCreated if null
         $this->update($table, [
-            $column => new Expression('DATE(`dateCreated`)'),
+            $column => new Expression($castDateExpr),
         ], [
             $column => null,
         ]);
 
-        // Make digestDate NOT NULL if all rows have it set
+        // Deduplicate rows: keep only latest ID per (type, digestDate)
+        $rows = (new Query())
+            ->select([
+                'id',
+                'type',
+                new Expression("{$castDateExpr} AS {$alias}"),
+            ])
+            ->from($table)
+            ->orderBy(['id' => \SORT_DESC])
+            ->all()
+        ;
+
+        $seen = [];
+        foreach ($rows as $row) {
+            if (!isset($row['digestDate'])) {
+                \Craft::warning('Skipping row with missing digestDate: '.json_encode($row), __METHOD__);
+
+                continue;
+            }
+
+            $key = $row['type'].'|'.$row['digestDate'];
+            if (isset($seen[$key])) {
+                \Craft::$app->getDb()->createCommand()
+                    ->delete($table, ['id' => $row['id']])
+                    ->execute()
+                ;
+            } else {
+                $seen[$key] = true;
+            }
+        }
+
+        // Make digestDate NOT NULL
         $this->alterColumn($table, $column, $this->date()->notNull());
 
-        // Manually extract index names from the returned index metadata
+        // Add unique index on (type, digestDate) if it doesn't already exist
         $existingIndexes = \Craft::$app->db->schema->getTableIndexes($table);
         $indexNames = array_map(fn ($index) => $index->name ?? null, $existingIndexes);
 
-        // Add unique index on (type, digestDate) if not exists
         if (!\in_array($indexName, $indexNames, true)) {
             $this->createIndex(
                 $indexName,

--- a/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
+++ b/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+use yii\db\Expression;
+
+class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
+{
+    public function safeUp(): bool
+    {
+        $column = 'digestDate';
+        $table = '{{%freeform_notification_log}}';
+        $indexName = 'freeform_notification_log_type_digestDate_unique_idx';
+
+        // Add `digestDate` column if it doesn't exist
+        if (!$this->db->getTableSchema($table)->getColumn($column)) {
+            $this->addColumn($table, $column, $this->date()->after('type')->null()->defaultValue(null));
+        }
+
+        // Populate digestDate from dateCreated if null
+        $this->update($table, [
+            $column => new Expression('DATE(`dateCreated`)'),
+        ], [
+            $column => null,
+        ]);
+
+        // Make digestDate NOT NULL if all rows have it set
+        $this->alterColumn($table, $column, $this->date()->notNull());
+
+        // Manually extract index names from the returned index metadata
+        $existingIndexes = \Craft::$app->db->schema->getTableIndexes($table);
+        $indexNames = array_map(fn ($index) => $index->name ?? null, $existingIndexes);
+
+        // Add unique index on (type, digestDate) if not exists
+        if (!\in_array($indexName, $indexNames, true)) {
+            $this->createIndex(
+                $indexName,
+                $table,
+                ['type', $column],
+                true // unique
+            );
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        $column = 'digestDate';
+        $table = '{{%freeform_notification_log}}';
+        $indexName = 'freeform_notification_log_type_digestDate_unique_idx';
+
+        // Drop the unique index if it exists
+        $existingIndexes = \Craft::$app->db->schema->getTableIndexes($table);
+        $indexNames = array_map(fn ($index) => $index->name ?? null, $existingIndexes);
+
+        if (\in_array($indexName, $indexNames, true)) {
+            $this->dropIndex($indexName, $table);
+        }
+
+        // Drop the column if it exists
+        if ($this->db->getTableSchema($table)->getColumn($column)) {
+            $this->dropColumn($table, $column);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Improved locking by moving the locking inside `DigestService::triggerDigest()`. Checking the lock in `DigestBundle::triggerDigest()`, before queuing the job was too late as once jobs started running, Craft's queue runs synchronously in the same request, and jobs are run immediately and sequentially. This eliminates race conditions so only one `triggerDigest()` fires before a lock is applied and observed. `DigestService::triggerDigest()` still has a lock that prevents multiple jobs filled up the queue causing noise, so not all is lost in that aspect.

We now create a notification log record before sending the email because we were checking if a record exists first, then send the digest, then insert the `NotificationLogRecord`. By the time the log record is saved, another job could have already reached the send stage. This was identified by inspecting server logs from Kelseys brothers server. Also added DB Transaction to sending the email incase it fails so job can be triggered as failed. 

Added unique flag to send digest job to help Craft avoid queuing duplicates and not retry automatically if failed. Now that the real locking is within `DigestService::triggerDigest()`, now if a job was added 30x and 5 failed, this prevents duplicates occurring. Also added `getUniqueId` so we can clearly see duplicates going forward, if duplicates were to occur.

Added unique constraint to `NotificationLogRecord` table to ensure only one record per type per `digestDate`, where `digestDate` is derived from the frequency window (day/week)

Added automatic purging of old notification logs to prevent bloat

Improved logging information

<img width="858" height="222" alt="image" src="https://github.com/user-attachments/assets/b1dec6b0-10cb-41a0-b5a4-4cdd66bb060f" />

<img width="2145" height="4035" alt="image" src="https://github.com/user-attachments/assets/7451a1a6-c683-4fa9-909e-b813876ccc9f" />

<img width="2153" height="1088" alt="image" src="https://github.com/user-attachments/assets/199bb3b7-50e8-4735-ac82-3b19a7ad95a9" />

<img width="2375" height="438" alt="image" src="https://github.com/user-attachments/assets/647c1e64-3bba-428e-abe4-29ad65fee4a0" />


in my debug logs screenshot, I triggered new digest emails. I then cleared cache to trigger another round of processing to show it correctly locking and preventing duplicates.
