### PR TITLE
fix(SFT-2280): duplicate key name error when running latest migration

### DIFF
--- a/packages/plugin/src/migrations/Install.php
+++ b/packages/plugin/src/migrations/Install.php
@@ -132,7 +132,7 @@ class Install extends StreamlinedInstallMigration
                 ->addField('includeAttachments', $this->boolean()->defaultValue(true))
                 ->addField('presetAssets', $this->string(255))
                 ->addField('sortOrder', $this->integer())
-                ->addIndex(['formId', 'handle'], true, name: 'formId_handle')
+                ->addIndex(['formId'], true, name: 'formId')
                 ->addForeignKey('formId', 'freeform_forms', 'id', ForeignKey::CASCADE)
                 ->addForeignKey('wrapperId', 'freeform_notification_template_wrappers', 'id', ForeignKey::SET_NULL, name: 'fk_wrapperId'),
 

--- a/packages/plugin/src/migrations/m250730_145048_AddFormIdToNotificationTemplates.php
+++ b/packages/plugin/src/migrations/m250730_145048_AddFormIdToNotificationTemplates.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+
+class m250730_145048_AddFormIdToNotificationTemplates extends Migration
+{
+    private const TABLE = '{{%freeform_notification_templates}}';
+
+    public function safeUp(): bool
+    {
+        if (!$this->db->columnExists(self::TABLE, 'formId')) {
+            $this->addColumn(self::TABLE, 'formId', $this->integer()->after('id'));
+            $this->addForeignKey(
+                null,
+                self::TABLE,
+                ['formId'],
+                '{{%freeform_forms}}',
+                ['id'],
+                'CASCADE'
+            );
+
+            if ('pgsql' === $this->db->driverName) {
+                $this->execute(
+                    \sprintf(
+                        'ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                        self::TABLE,
+                        'freeform_notification_templates_handle_key'
+                    )
+                );
+            } else {
+                $this->dropIndexIfExists(self::TABLE, 'handle', true);
+            }
+
+            $this->createIndex('freeform_notification_templates_formId_handle', self::TABLE, ['formId', 'handle'], true);
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists(self::TABLE, 'formId')) {
+            // find the foreign key name
+            $foreignKeys = $this->db->getSchema()->getTableForeignKeys(self::TABLE);
+            foreach ($foreignKeys as $foreignKey) {
+                if ($foreignKey->columnNames === ['formId']) {
+                    $this->dropForeignKey($foreignKey->name, self::TABLE);
+
+                    break;
+                }
+            }
+
+            if ('pgsql' === $this->db->driverName) {
+                $this->execute(
+                    \sprintf(
+                        'ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                        self::TABLE,
+                        'freeform_notification_templates_formId_handle_key'
+                    )
+                );
+            } else {
+                $this->dropIndexIfExists(self::TABLE, ['formId', 'handle'], true);
+            }
+
+            $this->createIndex('freeform_notification_templates_handle', self::TABLE, ['handle'], true);
+            $this->dropColumn(self::TABLE, 'formId');
+        }
+
+        return true;
+    }
+}

--- a/packages/plugin/src/migrations/m250730_145058_RemoveUniqueHandleIndexFromNotificationTemplates.php
+++ b/packages/plugin/src/migrations/m250730_145058_RemoveUniqueHandleIndexFromNotificationTemplates.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+
+class m250730_145058_RemoveUniqueHandleIndexFromNotificationTemplates extends Migration
+{
+    private const TABLE = '{{%freeform_notification_templates}}';
+
+    public function safeUp(): bool
+    {
+        if ($this->db->columnExists(self::TABLE, 'formId') && $this->db->columnExists(self::TABLE, 'handle')) {
+            // find the foreign key name
+            $foreignKeys = $this->db->getSchema()->getTableForeignKeys(self::TABLE);
+            foreach ($foreignKeys as $foreignKey) {
+                if ($foreignKey->columnNames === ['formId'] || $foreignKey->columnNames === ['handle']) {
+                    $this->dropForeignKey($foreignKey->name, self::TABLE);
+
+                    break;
+                }
+            }
+
+            if ('pgsql' === $this->db->driverName) {
+                $this->execute(
+                    \sprintf(
+                        'ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s',
+                        self::TABLE,
+                        'freeform_notification_templates_formId_handle_key'
+                    )
+                );
+            } else {
+                $this->dropIndexIfExists(self::TABLE, ['formId', 'handle'], true);
+            }
+
+            $this->createIndex('freeform_notification_templates_formId', self::TABLE, ['formId'], true);
+
+            $this->addForeignKey(
+                null,
+                self::TABLE,
+                ['formId'],
+                '{{%freeform_forms}}',
+                ['id'],
+                'CASCADE'
+            );
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Re-adding last 2 migrations again but with correct timestamps so they actually run.