### PR TITLE
[#2180]: field page index is not being assigned

### DIFF
--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -478,6 +478,13 @@ abstract class AbstractField implements FieldInterface, IdentificatorInterface
         return $this->pageIndex;
     }
 
+    public function setPageIndex(int $pageIndex): self
+    {
+        $this->pageIndex = $pageIndex;
+
+        return $this;
+    }
+
     /**
      * Gets whatever value is set and returns its string representation.
      */

--- a/packages/plugin/src/Services/Form/LayoutsService.php
+++ b/packages/plugin/src/Services/Form/LayoutsService.php
@@ -191,6 +191,8 @@ class LayoutsService extends BaseService
                 $page->getFields()->add($field);
                 $row->getAllFields()->add($field);
 
+                $field->setPageIndex($page->getIndex());
+
                 if ($field instanceof NoRenderInterface || !$field->canRender()) {
                     continue;
                 }


### PR DESCRIPTION
### Related Ticket Number
#2180

### Description
The field objects in the form layout have a `pageIndex` property, which is always `0` because it is not being set during the layout wiring process.

- assign the correct `pageIndex` to field objects during construction