### PR TITLE
fix(SFT-2404): submission mutations to use the form resolver instead of $context

### DIFF
--- a/packages/plugin/src/Bundles/GraphQL/GqlPermissions.php
+++ b/packages/plugin/src/Bundles/GraphQL/GqlPermissions.php
@@ -16,7 +16,7 @@ class GqlPermissions extends Gql
      */
     public static function canCreateAllSubmissions(): bool
     {
-        return self::canSchema(self::CATEGORY_SUBMISSIONS.'.all', 'create');
+        return self::canSchema(self::CATEGORY_SUBMISSIONS.'.all', 'create') || self::canSchema(self::CATEGORY_SUBMISSIONS.'.all', 'save');
     }
 
     /**
@@ -24,7 +24,7 @@ class GqlPermissions extends Gql
      */
     public static function canCreateSubmissions(string $formUid): bool
     {
-        return self::canSchema(self::CATEGORY_SUBMISSIONS.'.'.$formUid, 'create');
+        return self::canSchema(self::CATEGORY_SUBMISSIONS.'.'.$formUid, 'create') || self::canSchema(self::CATEGORY_SUBMISSIONS.'.'.$formUid, 'save');
     }
 
     /**
@@ -37,13 +37,11 @@ class GqlPermissions extends Gql
 
     public static function allowedFormUids(): array
     {
-        $formUids = self::extractAllowedEntitiesFromSchema('read')[self::CATEGORY_FORMS] ?? [];
+        $formUidsByAction = self::extractAllowedEntitiesFromSchema();
+        $formUids = $formUidsByAction[self::CATEGORY_FORMS] ?? [];
 
-        return array_filter(array_filter(
-            $formUids,
-            function ($item) {
-                return 'all' !== $item;
-            }
-        ));
+        return array_values(array_filter($formUids, function ($uid) {
+            return 'all' !== $uid;
+        }));
     }
 }

--- a/packages/plugin/src/Bundles/GraphQL/Resolvers/Mutations/SubmissionMutationResolver.php
+++ b/packages/plugin/src/Bundles/GraphQL/Resolvers/Mutations/SubmissionMutationResolver.php
@@ -26,15 +26,15 @@ class SubmissionMutationResolver extends ElementMutationResolver
      */
     public function saveSubmission(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): ?array
     {
-        if (!GqlPermissions::canCreateAllSubmissions() && !GqlPermissions::canCreateSubmissions($context->uid)) {
-            throw new Error('Unable to create Freeform submissions.');
-        }
-
         $form = $this->getResolutionData('form');
         if (!$form) {
-            throw new Error('Form with ID {id} not found', [
-                'id' => $context->id,
+            throw new Error('Form with handle {handle} not found', [
+                'handle' => $form->handle,
             ]);
+        }
+
+        if (!GqlPermissions::canCreateAllSubmissions() && !GqlPermissions::canCreateSubmissions($form->getUid())) {
+            throw new Error('Unable to create Freeform submissions.');
         }
 
         $properties = [];


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/2184

Nothing to do with permissions. 

Looks like a recent change to GraphQL removed info I was replying on to grab form info.
Also added `save` to action list. 

<img width="1417" height="407" alt="image" src="https://github.com/user-attachments/assets/c22607b9-b661-403f-8c7d-fc7f3d87ec72" />
