### PR TITLE
fix(#2241): fix php throwing job creation errors when submission or notification not present

### DIFF
--- a/packages/plugin/src/Events/Integrations/ProcessPostedValuesEvent.php
+++ b/packages/plugin/src/Events/Integrations/ProcessPostedValuesEvent.php
@@ -10,7 +10,7 @@ class ProcessPostedValuesEvent extends Event
 {
     public function __construct(
         private Form $form,
-        private Submission $submission,
+        private ?Submission $submission,
         private array $values,
     ) {
         parent::__construct();
@@ -21,7 +21,7 @@ class ProcessPostedValuesEvent extends Event
         return $this->form;
     }
 
-    public function getSubmission(): Submission
+    public function getSubmission(): ?Submission
     {
         return $this->submission;
     }

--- a/packages/plugin/src/Jobs/SendNotificationsJob.php
+++ b/packages/plugin/src/Jobs/SendNotificationsJob.php
@@ -115,7 +115,7 @@ class SendNotificationsJob extends BaseJob implements NotificationJobInterface
         return Freeform::t('Freeform: Processing Notifications');
     }
 
-    private function getLogger(NotificationInterface $notification, Form $form): LoggerInterface
+    private function getLogger(?NotificationInterface $notification, Form $form): LoggerInterface
     {
         $loggerProvider = \Craft::$container->get(NotificationLoggerProvider::class);
 


### PR DESCRIPTION
Upon creating notifications job, or processing posted values event, if a submission is empty or the notification is not present - php crashes.
This PR addresses that issue