### PR TITLE
fix(SFT-2490): search indexing for submissions

### DIFF
--- a/packages/plugin/src/Commands/SubmissionsController.php
+++ b/packages/plugin/src/Commands/SubmissionsController.php
@@ -102,6 +102,11 @@ class SubmissionsController extends Controller
                 'limit',
                 'siteId',
             ],
+            'reindex' => [
+                'limit',
+                'siteId',
+                'dryRun',
+            ],
         };
     }
 
@@ -294,6 +299,51 @@ class SubmissionsController extends Controller
 
         $label = 'resaving';
         $this->stdout("Done {$label} {$elementsText}.".\PHP_EOL.\PHP_EOL, Console::FG_YELLOW);
+
+        return ExitCode::OK;
+    }
+
+    /**
+     * Re-indexes submissions.
+     */
+    public function actionReindex(): int
+    {
+        if ($this->limit) {
+            $limit = $this->limit;
+        } else {
+            $limit = 200;
+        }
+
+        if ($this->siteId) {
+            if (\is_array($this->siteId)) {
+                $siteIds = array_map('intval', $this->siteId);
+            } else {
+                $siteIds = (int) $this->siteId;
+            }
+        } else {
+            $siteIds = \Craft::$app->sites->getAllSiteIds();
+        }
+
+        $query = Submission::find()
+            ->trashed(null)
+            ->siteId($siteIds)
+        ;
+
+        $total = $query->count();
+
+        $this->stdout("Reindexing {$total} Freeform submissions...\n");
+
+        if ($this->dryRun) {
+            $this->stdout("Dry run enabled. No submissions will be saved.\n\n", Console::FG_YELLOW);
+        } else {
+            foreach ($query->batch($limit) as $submissions) {
+                foreach ($submissions as $submission) {
+                    \Craft::$app->elements->saveElement($submission, false, false, true);
+                }
+            }
+        }
+
+        $this->stdout("Done.\n");
 
         return ExitCode::OK;
     }

--- a/packages/plugin/src/Library/Helpers/SearchHelper.php
+++ b/packages/plugin/src/Library/Helpers/SearchHelper.php
@@ -48,6 +48,7 @@ class SearchHelper
         $submission = $event->element;
         $attribute = CraftStringHelper::toLowerCase($event->attribute);
 
+        // if we have already indexed this attribute for this submission, skip it
         if ($submission->hasIndexedAttribute($attribute)) {
             $event->isValid = false;
 
@@ -55,5 +56,39 @@ class SearchHelper
         }
 
         $submission->addIndexedAttribute($attribute);
+
+        // always allow some core attributes (title etc)
+        $alwaysAllow = ['title'];
+        if (\in_array($attribute, $alwaysAllow, true)) {
+            return;
+        }
+
+        // only allow attributes that belong to this submission's form
+        $form = $submission->getForm();
+        if (!$form) {
+            // No form? Don't index this attribute
+            $event->isValid = false;
+
+            return;
+        }
+
+        static $allowedByForm = [];
+
+        $formId = $form->getId();
+
+        if (!isset($allowedByForm[$formId])) {
+            $handles = [];
+
+            foreach ($form->getLayout()->getFields() as $field) {
+                $handles[] = CraftStringHelper::toLowerCase(self::maybeTruncateHandle($field->getHandle()));
+            }
+
+            $allowedByForm[$formId] = array_unique($handles);
+        }
+
+        if (!\in_array($attribute, $allowedByForm[$formId], true)) {
+            // Attribute does not belong to this form so don't index
+            $event->isValid = false;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/2266

Previously all fields from all forms where being added as global searchable attributes and indexed for a submission even though some fields didn't belong to the submission. Causing massive bloat in the search index. 
Now we're filtering the global search attributes, so when a submission is indexed, only its own specific form fields are included. 

First step to fixing this is to delete all rows for any submissions (adjust table names and/or prefixes Craft 5 schema):

`DELETE si FROM searchindex si INNER JOIN freeform_submissions fs ON fs.id = si.elementId;`

Second step is to update to latest Freeform version (this PR).

Third step is to reindex all submissions again:

`php craft freeform/submissions/reindex`

