### PR TITLE
[SFT-2509]: Migration issues for PostgreSQL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "solspace/craft-freeform",
   "description": "The most flexible and user-friendly form building plugin!",
-  "version": "5.13.6",
+  "version": "5.13.6.1",
   "type": "craft-plugin",
   "authors": [
     {

--- a/packages/plugin/src/Attributes/Integration/Type.php
+++ b/packages/plugin/src/Attributes/Integration/Type.php
@@ -7,7 +7,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class Type
+class Type implements \Stringable
 {
     public const TYPE_CAPTCHAS = 'captchas';
     public const TYPE_CRM = 'crm';

--- a/packages/plugin/src/Attributes/Property/Implementations/Options/Option.php
+++ b/packages/plugin/src/Attributes/Property/Implementations/Options/Option.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Attributes\Property\Implementations\Options;
 
-class Option
+class Option implements \Stringable
 {
     public function __construct(
         private string $value,

--- a/packages/plugin/src/Fields/AbstractField.php
+++ b/packages/plugin/src/Fields/AbstractField.php
@@ -51,7 +51,7 @@ use yii\base\Event;
 /**
  * @template T
  */
-abstract class AbstractField implements FieldInterface, IdentificatorInterface
+abstract class AbstractField implements \Stringable, FieldInterface, IdentificatorInterface
 {
     #[Translatable]
     #[Validators\Required]

--- a/packages/plugin/src/Fields/DataContainers/Option.php
+++ b/packages/plugin/src/Fields/DataContainers/Option.php
@@ -13,7 +13,7 @@
 
 namespace Solspace\Freeform\Fields\DataContainers;
 
-class Option
+class Option implements \Stringable
 {
     public function __construct(
         private string $label,

--- a/packages/plugin/src/Fields/Properties/OpinionScale/Legend.php
+++ b/packages/plugin/src/Fields/Properties/OpinionScale/Legend.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Fields\Properties\OpinionScale;
 
-class Legend
+class Legend implements \Stringable
 {
     public function __construct(private string $label) {}
 

--- a/packages/plugin/src/Fields/Properties/OpinionScale/Scale.php
+++ b/packages/plugin/src/Fields/Properties/OpinionScale/Scale.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Fields\Properties\OpinionScale;
 
-class Scale
+class Scale implements \Stringable
 {
     public function __construct(
         private string $value,

--- a/packages/plugin/src/Form/Form.php
+++ b/packages/plugin/src/Form/Form.php
@@ -68,7 +68,7 @@ use Twig\Markup;
 use yii\base\Event;
 use yii\web\Request;
 
-abstract class Form implements FormTypeInterface, \IteratorAggregate, CustomNormalizerInterface, \JsonSerializable
+abstract class Form implements \Stringable, FormTypeInterface, \IteratorAggregate, CustomNormalizerInterface, \JsonSerializable
 {
     public const HASH_KEY = 'hash';
     public const ACTION_KEY = 'freeform-action';

--- a/packages/plugin/src/Library/Attributes/Attributes.php
+++ b/packages/plugin/src/Library/Attributes/Attributes.php
@@ -8,7 +8,7 @@ use Solspace\Freeform\Library\Helpers\StringHelper;
 use Solspace\Freeform\Library\Serialization\Normalizers\CustomNormalizerInterface;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
-class Attributes implements CustomNormalizerInterface, \Countable, \JsonSerializable, \IteratorAggregate
+class Attributes implements \Stringable, CustomNormalizerInterface, \Countable, \JsonSerializable, \IteratorAggregate
 {
     public const STRATEGY_APPEND = 'append';
     public const STRATEGY_REMOVE = 'remove';

--- a/packages/plugin/src/Library/Configuration/BaseConfiguration.php
+++ b/packages/plugin/src/Library/Configuration/BaseConfiguration.php
@@ -4,7 +4,7 @@ namespace Solspace\Freeform\Library\Configuration;
 
 use Solspace\Freeform\Library\Exceptions\Configurations\ConfigurationException;
 
-abstract class BaseConfiguration
+abstract class BaseConfiguration implements \Stringable
 {
     /**
      * BaseConfiguration constructor.

--- a/packages/plugin/src/Library/Helpers/EditionHelper.php
+++ b/packages/plugin/src/Library/Helpers/EditionHelper.php
@@ -2,7 +2,7 @@
 
 namespace Solspace\Freeform\Library\Helpers;
 
-class EditionHelper
+class EditionHelper implements \Stringable
 {
     private ?int $editionIndex = null;
 

--- a/packages/plugin/src/Library/Migrations/Field.php
+++ b/packages/plugin/src/Library/Migrations/Field.php
@@ -4,7 +4,7 @@ namespace Solspace\Freeform\Library\Migrations;
 
 use yii\db\ColumnSchemaBuilder;
 
-class Field
+class Field implements \Stringable
 {
     private string $name;
 

--- a/packages/plugin/src/Library/Migrations/ForeignKey.php
+++ b/packages/plugin/src/Library/Migrations/ForeignKey.php
@@ -4,7 +4,7 @@ namespace Solspace\Freeform\Library\Migrations;
 
 use Solspace\Freeform\Library\Exceptions\Database\DatabaseException;
 
-class ForeignKey
+class ForeignKey implements \Stringable
 {
     public const CASCADE = 'CASCADE';
     public const UPDATE = 'UPDATE';

--- a/packages/plugin/src/Library/Migrations/Table.php
+++ b/packages/plugin/src/Library/Migrations/Table.php
@@ -4,7 +4,7 @@ namespace Solspace\Freeform\Library\Migrations;
 
 use yii\db\ColumnSchemaBuilder;
 
-class Table
+class Table implements \Stringable
 {
     private string $name;
 

--- a/packages/plugin/src/Models/StatusModel.php
+++ b/packages/plugin/src/Models/StatusModel.php
@@ -26,7 +26,7 @@ use Solspace\Freeform\Records\StatusRecord;
  * @property string $color
  * @property int    $sortOrder
  */
-class StatusModel extends Model implements \JsonSerializable
+class StatusModel extends Model implements \Stringable, \JsonSerializable
 {
     public ?int $id = null;
     public string $name = '';

--- a/packages/plugin/src/migrations/m250704_092101_ChangeWrapperNameIndexToHandle.php
+++ b/packages/plugin/src/migrations/m250704_092101_ChangeWrapperNameIndexToHandle.php
@@ -8,28 +8,30 @@ class m250704_092101_ChangeWrapperNameIndexToHandle extends Migration
 {
     public function safeUp(): bool
     {
-        if (!\Craft::$app->getDb()->tableExists('{{%freeform_notification_template_wrappers}}')) {
+        $table = '{{%freeform_notification_template_wrappers}}';
+
+        if (!\Craft::$app->getDb()->tableExists($table)) {
             return true;
         }
 
-        // Drop the existing name index
+        // Drop the old "name" index if it exists
         $this->dropIndexIfExists(
-            '{{%freeform_notification_template_wrappers}}',
+            $table,
             ['name'],
-            true,
+            true
         );
 
-        // Drop an index literally named "handle" if it exists
-        try {
-            $this->dropIndex('handle', '{{%freeform_notification_template_wrappers}}');
-        } catch (\Throwable $e) {
-            // ignore if it doesn't exist
-        }
+        // Drop any existing index on the "handle" column if it exists
+        $this->dropIndexIfExists(
+            $table,
+            ['handle'],
+            true
+        );
 
-        // Create a new index on the handle column
+        // Create a new unique index on "handle"
         $this->createIndex(
-            'handle',
-            '{{%freeform_notification_template_wrappers}}',
+            'freeform_notification_template_wrappers_handle_idx',
+            $table,
             ['handle'],
             true
         );
@@ -39,28 +41,23 @@ class m250704_092101_ChangeWrapperNameIndexToHandle extends Migration
 
     public function safeDown(): bool
     {
-        if (!\Craft::$app->getDb()->tableExists('{{%freeform_notification_template_wrappers}}')) {
+        $table = '{{%freeform_notification_template_wrappers}}';
+
+        if (!\Craft::$app->getDb()->tableExists($table)) {
             return true;
         }
 
-        // Drop the handle index by name
-        try {
-            $this->dropIndex('handle', '{{%freeform_notification_template_wrappers}}');
-        } catch (\Throwable $e) {
-            // ignore if it doesn't exist
-        }
-
-        // Also try dropping by columns in case a canonical one exists
+        // Drop the "handle" index if it exists
         $this->dropIndexIfExists(
-            '{{%freeform_notification_template_wrappers}}',
+            $table,
             ['handle'],
-            true,
+            true
         );
 
-        // Recreate the name index
+        // Recreate the unique index on "name"
         $this->createIndex(
-            'name',
-            '{{%freeform_notification_template_wrappers}}',
+            'freeform_notification_template_wrappers_name_idx',
+            $table,
             ['name'],
             true
         );

--- a/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
+++ b/packages/plugin/src/migrations/m250724_111642_AddDigestDateToNotificationLogTable.php
@@ -14,26 +14,42 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
         $table = '{{%freeform_notification_log}}';
         $indexName = 'freeform_notification_log_type_digestDate_unique_idx';
 
-        // Determine correct casting expression based on DB driver
-        $driver = \Craft::$app->getDb()->getDriverName();
-        $castDateExpr = 'pgsql' === $driver
-            ? 'CAST("dateCreated" AS DATE)'
-            : 'CAST(`dateCreated` AS DATE)';
-        $alias = 'pgsql' === $driver ? '"digestDate"' : 'digestDate';
+        // Check if table exists before touching anything
+        $schema = $this->db->getTableSchema($table);
+        if (!$schema) {
+            \Craft::warning("Skipping digestDate migration: {$table} does not exist", __METHOD__);
 
-        // Add `digestDate` column if it doesn't exist
-        if (!$this->db->getTableSchema($table)->getColumn($column)) {
-            $this->addColumn($table, $column, $this->date()->after('type')->null()->defaultValue(null));
+            return true;
         }
 
-        // Populate digestDate from dateCreated if null
-        $this->update($table, [
-            $column => new Expression($castDateExpr),
-        ], [
-            $column => null,
-        ]);
+        // Determine correct casting expression based on DB driver
+        $driver = \Craft::$app->getDb()->getDriverName();
 
-        // Deduplicate rows: keep only latest ID per (type, digestDate)
+        // Use Yii auto-quoting for column name
+        $castDateExpr = 'pgsql' === $driver
+            ? 'CAST([[dateCreated]] AS DATE)'
+            : 'CAST([[dateCreated]] AS DATE)';
+
+        // Alias should ALWAYS be plain `digestDate`
+        $alias = 'digestDate';
+
+        // Add digestDate column if missing
+        if (!$schema->getColumn($column)) {
+            $this->addColumn(
+                $table,
+                $column,
+                $this->date()->after('type')->null()->defaultValue(null)
+            );
+        }
+
+        // Populate digestDate from dateCreated where null
+        $this->update(
+            $table,
+            [$column => new Expression($castDateExpr)],
+            [$column => null]
+        );
+
+        // Dedupe: keep latest ID per (type, digestDate)
         $rows = (new Query())
             ->select([
                 'id',
@@ -48,14 +64,19 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
         $seen = [];
         foreach ($rows as $row) {
             if (!isset($row['digestDate'])) {
-                \Craft::warning('Skipping row with missing digestDate: '.json_encode($row), __METHOD__);
+                \Craft::warning(
+                    'Skipping row with missing digestDate: '.json_encode($row),
+                    __METHOD__
+                );
 
                 continue;
             }
 
             $key = $row['type'].'|'.$row['digestDate'];
+
+            // Remove duplicates
             if (isset($seen[$key])) {
-                \Craft::$app->getDb()->createCommand()
+                \Craft::$app->db->createCommand()
                     ->delete($table, ['id' => $row['id']])
                     ->execute()
                 ;
@@ -67,9 +88,9 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
         // Make digestDate NOT NULL
         $this->alterColumn($table, $column, $this->date()->notNull());
 
-        // Add unique index on (type, digestDate) if it doesn't already exist
+        // Add unique index if missing
         $existingIndexes = \Craft::$app->db->schema->getTableIndexes($table);
-        $indexNames = array_map(fn ($index) => $index->name ?? null, $existingIndexes);
+        $indexNames = array_map(fn ($i) => $i->name ?? null, $existingIndexes);
 
         if (!\in_array($indexName, $indexNames, true)) {
             $this->createIndex(
@@ -89,16 +110,21 @@ class m250724_111642_AddDigestDateToNotificationLogTable extends Migration
         $table = '{{%freeform_notification_log}}';
         $indexName = 'freeform_notification_log_type_digestDate_unique_idx';
 
-        // Drop the unique index if it exists
+        $schema = $this->db->getTableSchema($table);
+        if (!$schema) {
+            return true;
+        }
+
+        // Drop unique index
         $existingIndexes = \Craft::$app->db->schema->getTableIndexes($table);
-        $indexNames = array_map(fn ($index) => $index->name ?? null, $existingIndexes);
+        $indexNames = array_map(fn ($i) => $i->name ?? null, $existingIndexes);
 
         if (\in_array($indexName, $indexNames, true)) {
             $this->dropIndex($indexName, $table);
         }
 
-        // Drop the column if it exists
-        if ($this->db->getTableSchema($table)->getColumn($column)) {
+        // Drop digestDate column if it exists
+        if ($schema->getColumn($column)) {
             $this->dropColumn($table, $column);
         }
 


### PR DESCRIPTION
- Fixed a PostgreSQL migration error related to dropping the wrapper index, ensuring the migration runs correctly on all database engines.
- Fixed an issue where the notification log migration could fail if the `freeform_notification_log` table was missing, and corrected digestDate handling for full cross-database compatibility.