### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [v5]
 
+permissions:
+  contents: read
+
 jobs:
   php-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/solspace/craft-freeform/security/code-scanning/5](https://github.com/solspace/craft-freeform/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal required scope. These jobs only check out code, cache dependencies, install via Composer, and run linters/tests, so they need only read access to repository contents. The best fix with minimal change is to set a workflow-level `permissions` block right after the `on:` section, e.g. `permissions: contents: read`. This automatically applies to all jobs that do not define their own `permissions`, so we don’t need to duplicate configuration in each job.

Concretely, in `.github/workflows/php.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` trigger configuration (after line 5), keeping the existing indentation pattern. No other lines, steps, or jobs need to be modified, and no new actions or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
