### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -1,5 +1,8 @@
 name: Builder
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [v5]

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [v5]
 
+permissions:
+  contents: read
+
 jobs:
   php-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/solspace/craft-freeform/security/code-scanning/1](https://github.com/solspace/craft-freeform/security/code-scanning/1)

In general, this issue is fixed by explicitly defining a minimal `permissions` block in the workflow so that the `GITHUB_TOKEN` only has the scopes required for the jobs. Since this workflow only checks out code, caches dependencies, installs composer packages, and runs linters/tests, it only needs read access to the repository contents.

The best fix without changing existing functionality is to add a root-level `permissions` block with `contents: read`. This will apply to all jobs (`php-lint`, `php-compat`, `php-tests`) since they do not define their own `permissions`. No additional scopes (like `pull-requests` or `issues`) are needed, because the jobs don’t write back to GitHub (no comments, no status posting beyond what GitHub does automatically). Concretely, in `.github/workflows/php.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (after line 5 and before line 7 in the snippet). No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
