### PR TITLE
fix(SFT-2590): Craft ^5.9 where it throws an error because craftcms/cms no longer uses the Stringy package

### DIFF
--- a/packages/plugin/src/Bundles/Attributes/Property/PropertyProvider.php
+++ b/packages/plugin/src/Bundles/Attributes/Property/PropertyProvider.php
@@ -3,6 +3,7 @@
 namespace Solspace\Freeform\Bundles\Attributes\Property;
 
 use Carbon\Carbon;
+use craft\helpers\StringHelper;
 use Solspace\Freeform\Attributes\Property\DefaultValue;
 use Solspace\Freeform\Attributes\Property\Delimiter;
 use Solspace\Freeform\Attributes\Property\Edition;
@@ -38,7 +39,6 @@ use Solspace\Freeform\Form\Form;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\Helpers\AttributeHelper;
 use Solspace\Freeform\Library\Helpers\EditionHelper;
-use Stringy\Stringy;
 use yii\di\Container;
 
 /**
@@ -150,11 +150,9 @@ class PropertyProvider
             $this->processValue($property, $attribute, $referenceObject, $context);
 
             /** @var Section $section */
-            $fallbackLabel = Stringy::create($property->getName())
-                ->underscored()
-                ->replace('_', ' ')
-                ->toTitleCase()
-            ;
+            $fallbackLabel = StringHelper::dasherize($property->getName());
+            $fallbackLabel = StringHelper::replace($fallbackLabel, '-', ' ');
+            $fallbackLabel = StringHelper::toTitleCase($fallbackLabel);
 
             $attribute->section = $section?->handle;
             $attribute->type = $this->processType($property, $attribute);

--- a/packages/plugin/src/Bundles/Fields/ImplementationProvider.php
+++ b/packages/plugin/src/Bundles/Fields/ImplementationProvider.php
@@ -2,10 +2,10 @@
 
 namespace Solspace\Freeform\Bundles\Fields;
 
+use craft\helpers\StringHelper;
 use Solspace\Freeform\Fields\FieldInterface;
 use Solspace\Freeform\Fields\Interfaces\ExtraFieldInterface;
 use Solspace\Freeform\Library\Serialization\Normalizers\IdentificatorInterface;
-use Stringy\Stringy;
 
 class ImplementationProvider
 {
@@ -58,10 +58,10 @@ class ImplementationProvider
 
                 if (!empty($matches)) {
                     $match = $matches[1];
-                    $name = str_replace($match, Stringy::create($match)->toLowerCase(), $name);
+                    $name = str_replace($match, StringHelper::toLowerCase($match), $name);
                 }
 
-                return Stringy::create($name)->camelize()->toString();
+                return StringHelper::toCamelCase($name);
             },
             $interfaces
         );


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/2361