### PR TITLE
fix(SFT-2605): invisible field value set at template level not showing in submissions or notifications

### DIFF
--- a/packages/plugin/src/Fields/Implementations/Pro/InvisibleField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/InvisibleField.php
@@ -36,6 +36,6 @@ class InvisibleField extends HiddenField implements ExtraFieldInterface, Persist
 
     public function getValue(): string
     {
-        return $this->getDefaultValue();
+        return $this->value ?? $this->getDefaultValue();
     }
 }

--- a/packages/plugin/src/Jobs/SendNotificationsJob.php
+++ b/packages/plugin/src/Jobs/SendNotificationsJob.php
@@ -104,7 +104,7 @@ class SendNotificationsJob extends BaseJob implements NotificationJobInterface
         $event = new ProcessPostedValuesEvent($form, $submission, $this->postedData);
         Event::trigger(FormJobInterface::class, FormJobInterface::EVENT_PROCESS_POSTED_DATA, $event);
 
-        $form->valuesFromArray($event->getValues());
+        $form->valuesFromSubmission($event->getSubmission());
 
         $freeform->mailer->sendEmail(
             $form,


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/2373 and https://github.com/solspace/craft-freeform/issues/2339
 and maybe https://github.com/solspace/craft-freeform/issues/2343

@gustavs-gutmanis 

`$form->valuesFromArray($event->getValues());` <--- this was losing the field value from the request and therefore not setting `value`. Fallback to `defaultValue` again.

`$form->valuesFromSubmission($event->getSubmission());` <--- this was correctly setting the field values from the request/live submission that we carry throughout the flow.