### PR TITLE
[SFT-2614][#2383]: add a migration that fixes the table names for Craft 5.9 and 4.17

### DIFF
--- a/packages/plugin/src/Commands/SubmissionsController.php
+++ b/packages/plugin/src/Commands/SubmissionsController.php
@@ -11,6 +11,7 @@ use Solspace\Freeform\Bundles\Form\Submissions\FakeDataProvider;
 use Solspace\Freeform\Commands\Fix\TitleFixMigration;
 use Solspace\Freeform\Elements\Submission;
 use Solspace\Freeform\Fields\Implementations\Pro\SignatureField;
+use Solspace\Freeform\Form\Managers\ContentFixManager;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Records\Form\FormSiteRecord;
 use yii\console\ExitCode;
@@ -243,6 +244,27 @@ class SubmissionsController extends Controller
         $migration->run();
 
         $this->stdout('Submission titles fixed.'.\PHP_EOL, Console::FG_YELLOW);
+
+        return ExitCode::OK;
+    }
+
+    public function actionFixTableNames(): int
+    {
+        $this->stdout('Fixing submission table names...'.\PHP_EOL, Console::FG_YELLOW);
+
+        $manager = new ContentFixManager();
+
+        $manager->onRename = function (string $table, string $oldTable, string $newTable) {
+            $this->stdout("Renaming table {$oldTable} to {$newTable}".\PHP_EOL, Console::FG_YELLOW);
+        };
+
+        $manager->onNotFound = function (string $table) {
+            $this->stdout("Could not find form handle for submission table {$table}".\PHP_EOL, Console::FG_YELLOW);
+        };
+
+        $count = $manager->fixTableNames();
+
+        $this->stdout($count.' submission table names fixed.'.\PHP_EOL, Console::FG_YELLOW);
 
         return ExitCode::OK;
     }

--- a/packages/plugin/src/Form/Managers/ContentFixManager.php
+++ b/packages/plugin/src/Form/Managers/ContentFixManager.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Solspace\Freeform\Form\Managers;
+
+use craft\db\Query;
+use Solspace\Freeform\Elements\Submission;
+
+class ContentFixManager
+{
+    public mixed $onRename = null;
+    public mixed $onNotFound = null;
+
+    public function fixTableNames(): int
+    {
+        $database = \Craft::$app->db;
+        $forms = (new Query())
+            ->select(['id', 'handle'])
+            ->from('{{%freeform_forms}}')
+            ->pairs()
+        ;
+
+        $count = 0;
+
+        $tables = $database->schema->getTableNames();
+        foreach ($tables as $table) {
+            if (!preg_match('/(freeform_submissions_)(.*)_(\d+)$/', $table, $matches)) {
+                continue;
+            }
+
+            $oldTableName = '{{%'.$matches[1].$matches[2].'_'.$matches[3].'}}';
+            $formId = (int) $matches[3];
+
+            $originalHandle = $forms[$formId] ?? null;
+            if (!$originalHandle) {
+                if (\is_callable($this->onNotFound)) {
+                    \call_user_func($this->onNotFound, $table);
+                }
+
+                continue;
+            }
+
+            $newTableName = Submission::generateContentTableName($formId, $originalHandle);
+
+            if ($newTableName === $oldTableName) {
+                continue;
+            }
+
+            if (\is_callable($this->onRename)) {
+                \call_user_func($this->onRename, $table, $oldTableName, $newTableName);
+            }
+
+            $database
+                ->createCommand()
+                ->renameTable($oldTableName, $newTableName)
+                ->execute()
+            ;
+
+            ++$count;
+        }
+
+        return $count;
+    }
+}

--- a/packages/plugin/src/migrations/m260204_155056_FixSubmissionTableNamesForCraft59.php
+++ b/packages/plugin/src/migrations/m260204_155056_FixSubmissionTableNamesForCraft59.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+use Solspace\Freeform\Form\Managers\ContentFixManager;
+
+class m260204_155056_FixSubmissionTableNamesForCraft59 extends Migration
+{
+    public function safeUp(): bool
+    {
+        $craftVersion = \Craft::$app->getVersion();
+
+        $runForCraft4 = version_compare($craftVersion, '4.17.0', '>=') && version_compare($craftVersion, '5.0.0', '<');
+        $runForCraft5 = version_compare($craftVersion, '5.9.0', '>=');
+
+        if (!($runForCraft4 || $runForCraft5)) {
+            return true;
+        }
+
+        $manager = new ContentFixManager();
+
+        $manager->onNotFound = static function ($table) {
+            echo "Could not find form handle for submission table {$table}\n";
+        };
+
+        $manager->onRename = static function ($table, $oldTable, $newTable) {
+            echo "Renaming table {$oldTable} to {$newTable}\n";
+        };
+
+        $manager->fixTableNames();
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        echo "m260204_155056_FixSubmissionTableNamesForCraft59 cannot be reverted.\n";
+
+        return true;
+    }
+}


### PR DESCRIPTION
Also add a console command `freeform/submissions/fix-table-names` for manually running the fix
