### PR TITLE
fix(SFT-2644): migrating form handles and submission table names in Craft 5.9

### DIFF
--- a/packages/plugin/src/Elements/Submission.php
+++ b/packages/plugin/src/Elements/Submission.php
@@ -292,7 +292,12 @@ class Submission extends Element
 
         $maxHandleSize = 36 - $prefixLength;
 
-        $handle = CraftStringHelper::toSnakeCase($handle);
+        // DO NOT use StringHelper::toSnakeCase()
+        // Its behavior changed in Craft 5.9 (Stringy to Laravel Str::snake) and no longer replaces hyphens with underscores.
+        $handle = preg_replace('/([a-z\d])([A-Z])/', '$1_$2', $handle); // camelCase
+        $handle = preg_replace('/[^a-z0-9]+/i', '_', $handle);          // non-alphanumeric
+        $handle = strtolower($handle);
+        $handle = trim($handle, '_');
         $handle = CraftStringHelper::truncate($handle, $maxHandleSize, '');
         $handle = trim($handle, '-_');
 

--- a/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
+++ b/packages/plugin/src/migrations/m230101_100010_FF4to5_MigrateForms.php
@@ -186,7 +186,12 @@ class m230101_100010_FF4to5_MigrateForms extends Migration
                 continue;
             }
 
-            $formHandle = StringHelper::toSnakeCase($formHandle);
+            // DO NOT use StringHelper::toSnakeCase()
+            // Its behavior changed in Craft 5.9 (Stringy to Laravel Str::snake) and no longer replaces hyphens with underscores.
+            $formHandle = preg_replace('/([a-z\d])([A-Z])/', '$1_$2', $formHandle); // camelCase
+            $formHandle = preg_replace('/[^a-z0-9]+/i', '_', $formHandle);          // non-alphanumeric
+            $formHandle = strtolower($formHandle);
+            $formHandle = trim($formHandle, '_');
             $formHandle = StringHelper::truncate($formHandle, $maxHandleSize, '');
             $formHandle = trim($formHandle, '-_');
 

--- a/packages/plugin/src/migrations/m260223_205201_FixSubmissionTableNamesForCraft59.php
+++ b/packages/plugin/src/migrations/m260223_205201_FixSubmissionTableNamesForCraft59.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+use Solspace\Freeform\Form\Managers\ContentFixManager;
+
+class m260223_205201_FixSubmissionTableNamesForCraft59 extends Migration
+{
+    public function safeUp(): bool
+    {
+        $craftVersion = \Craft::$app->getVersion();
+
+        $runForCraft4 = version_compare($craftVersion, '4.17.0', '>=') && version_compare($craftVersion, '5.0.0', '<');
+        $runForCraft5 = version_compare($craftVersion, '5.9.0', '>=');
+
+        if (!($runForCraft4 || $runForCraft5)) {
+            return true;
+        }
+
+        $manager = new ContentFixManager();
+
+        $manager->onNotFound = static function ($table) {
+            echo "Could not find form handle for submission table {$table}\n";
+        };
+
+        $manager->onRename = static function ($table, $oldTable, $newTable) {
+            echo "Renaming table {$oldTable} to {$newTable}\n";
+        };
+
+        $manager->fixTableNames();
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        echo "m260223_205201_FixSubmissionTableNamesForCraft59 cannot be reverted.\n";
+
+        return true;
+    }
+}

--- a/packages/plugin/src/migrations/m260223_205201_FixSubmissionTableNamesForCraft59.php
+++ b/packages/plugin/src/migrations/m260223_205201_FixSubmissionTableNamesForCraft59.php
@@ -9,15 +9,6 @@ class m260223_205201_FixSubmissionTableNamesForCraft59 extends Migration
 {
     public function safeUp(): bool
     {
-        $craftVersion = \Craft::$app->getVersion();
-
-        $runForCraft4 = version_compare($craftVersion, '4.17.0', '>=') && version_compare($craftVersion, '5.0.0', '<');
-        $runForCraft5 = version_compare($craftVersion, '5.9.0', '>=');
-
-        if (!($runForCraft4 || $runForCraft5)) {
-            return true;
-        }
-
         $manager = new ContentFixManager();
 
         $manager->onNotFound = static function ($table) {


### PR DESCRIPTION
There was a bug in the migration script to fix tables in Craft 5.9. We were calling `Submission::generateContentTableName` class which in return was calling `StringHelper::toSnakeCase` again, so it was never actually fixing the issue.