### PR TITLE
fix(SFT-2654): Submission data is missing when resending an email notification

### DIFF
--- a/packages/plugin/src/Elements/Actions/Pro/ResendNotificationsAction.php
+++ b/packages/plugin/src/Elements/Actions/Pro/ResendNotificationsAction.php
@@ -27,7 +27,7 @@ class ResendNotificationsAction extends ElementAction
         $mailer = Freeform::getInstance()->mailer;
 
         /** @var Submission $submission */
-        foreach ($query->all() as $submission) {
+        foreach ($query->skipContent(false)->all() as $submission) {
             $form = $submission->getForm();
             $form->valuesFromSubmission($submission);
 

--- a/packages/plugin/src/Elements/Db/SubmissionQuery.php
+++ b/packages/plugin/src/Elements/Db/SubmissionQuery.php
@@ -32,6 +32,7 @@ class SubmissionQuery extends ElementQuery
     public bool $skipContent = false;
     public mixed $formSiteId = null;
     private mixed $freeformStatus = null;
+    private bool $skipContentExplicit = false;
 
     public function formSiteId(mixed $value): self
     {
@@ -99,6 +100,7 @@ class SubmissionQuery extends ElementQuery
     public function skipContent(bool $value): self
     {
         $this->skipContent = $value;
+        $this->skipContentExplicit = true;
 
         return $this;
     }
@@ -201,16 +203,18 @@ class SubmissionQuery extends ElementQuery
             $source = \is_string($source) ? trim($source) : null;
 
             // If source="*" but Craft has already limited formId to a single allowed form (e.g. [1]), treat it as a single-form query so custom fields can still render safely.
-            if ('*' === $source) {
-                if (\is_array($this->formId) && 1 === \count($this->formId)) {
-                    $this->formId = (int) $this->formId[0];
+            if (!$this->skipContentExplicit) {
+                if ('*' === $source) {
+                    if (\is_array($this->formId) && 1 === \count($this->formId)) {
+                        $this->formId = (int) $this->formId[0];
 
-                    $this->skipContent = false;
+                        $this->skipContent = false;
+                    } else {
+                        $this->skipContent = true;
+                    }
                 } else {
-                    $this->skipContent = true;
+                    $this->skipContent = false;
                 }
-            } else {
-                $this->skipContent = false;
             }
         }
 


### PR DESCRIPTION
When the user is viewing All Submissions and selects Resend Notifications, our previous Submission query performance work was causing content to be skipped in the DB query. I added an explicit flag so we can include content in specific use cases like resending notifications.