### PR TITLE
fix(SFT-2610): too many columns error when trying to view the CP Orders index page with Craft Commerce installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "phpunit/phpunit": "^11.5.1",
     "friendsofphp/php-cs-fixer": "^3.85",
     "phpcompatibility/php-compatibility": "^9.3.5",
-    "squizlabs/php_codesniffer": "^3.13.2"
+    "squizlabs/php_codesniffer": "^3.13.2",
+    "craftcms/commerce": "^5"
   },
   "autoload": {
     "psr-4": {

--- a/packages/plugin/src/Elements/Db/SubmissionQuery.php
+++ b/packages/plugin/src/Elements/Db/SubmissionQuery.php
@@ -134,9 +134,15 @@ class SubmissionQuery extends ElementQuery
         $pathInfo = !$isConsoleRequest ? ($request->getPathInfo() ?? '') : '';
         $path = '/'.ltrim($pathInfo, '/');
 
+        $plugins = \Craft::$app->getPlugins();
+        $orderClass = 'craft\commerce\elements\Order';
+        $commerceAvailable = $plugins->isPluginInstalled('commerce') && $plugins->isPluginEnabled('commerce') && class_exists($orderClass);
+
         $isElementIndexAction = str_contains($path, 'actions/element-indexes/');
         $isSubmissionElementType = (!$isConsoleRequest) && (Submission::class === $request->getBodyParam('elementType'));
+        $isOrderElementType = $commerceAvailable && (!$isConsoleRequest) && ($orderClass === $request->getBodyParam('elementType'));
         $isCpSubmissionIndexRequest = $isCpRequest && $isElementIndexAction && $isSubmissionElementType;
+        $isCpOrderIndexRequest = $isCpRequest && $isElementIndexAction && $isOrderElementType;
 
         // Requested CP table columns (element attributes, field handles, field column names, or field IDs)
         $requestedFieldHandles = [];
@@ -212,6 +218,10 @@ class SubmissionQuery extends ElementQuery
             } else {
                 $this->skipContent = false;
             }
+        }
+
+        if ($isCpOrderIndexRequest) {
+            $this->skipContent = true;
         }
 
         if (null === $formHandleToIdMap) {


### PR DESCRIPTION
Craft Commerce order that includes a Freeform Submissions field still produces the “Too many columns" error.