### PR TITLE
chore(SFT-2651): improved Stripe webhooks status and debugging info when unrelated to Freeform

### DIFF
--- a/packages/plugin/src/Integrations/PaymentGateways/Stripe/Controllers/StripeWebhookController.php
+++ b/packages/plugin/src/Integrations/PaymentGateways/Stripe/Controllers/StripeWebhookController.php
@@ -47,6 +47,11 @@ class StripeWebhookController extends BaseStripeController
         $this->logger->debug('Received a Stripe Webhook', json_decode($payload, true) ?? []);
 
         if (!$json || !$header) {
+            $this->logger->warning('Stripe Webhook missing JSON or Stripe Signature', [
+                'json' => $json,
+                'header' => $header,
+            ]);
+
             return $this->asEmptyResponse(400);
         }
 
@@ -56,11 +61,17 @@ class StripeWebhookController extends BaseStripeController
             return $this->asEmptyResponse();
         }
 
-        try {
-            $hash = $json->data->object->subscription_details->metadata->hash ?? $json->data->object->metadata->hash;
-        } catch (\Exception $exception) {
-            $this->logger->error('Received a Stripe Webhook that does not contain a valid Freeform hash');
+        $hash = $json->data->object->subscription_details->metadata->hash
+            ?? $json->data->object->metadata->hash
+            ?? null;
 
+        if (!$hash) {
+            $this->logger->error('Received a Stripe Webhook that does not contain a valid Freeform hash', [
+                'type' => $json->type,
+                'json' => $json,
+            ]);
+
+            // Return 200 so Stripe doesn't keep retrying
             return $this->asEmptyResponse(200);
         }
 
@@ -96,13 +107,23 @@ class StripeWebhookController extends BaseStripeController
         /** @var PaymentIntent $paymentIntent */
         $paymentIntent = $event->data->object;
 
-        $hash = $paymentIntent?->metadata?->hash;
+        $hash = $paymentIntent->metadata->hash ?? null;
+
+        if (!$hash) {
+            $this->logger->error('Received a Stripe Webhook that does not contain a valid Freeform hash', [
+                'event' => $event,
+            ]);
+
+            // Return 200 so Stripe doesn't keep retrying
+            return $this->asEmptyResponse(200);
+        }
 
         try {
             [$form, $integration, $field] = $this->getRequestItems($hash);
         } catch (NotFoundHttpException $exception) {
             $this->logger->error('Stripe Webhook not related to Freeform', ['error' => $exception->getMessage()]);
 
+            // Return 200 so Stripe doesn't keep retrying
             return $this->asEmptyResponse(200);
         }
 


### PR DESCRIPTION
Little improvement in our try/catch logic as it wont catch empty hash values