### PR TITLE
fix(SFT-2731): active campaign integration authorisation

### DIFF
--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/BaseActiveCampaignIntegration.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/BaseActiveCampaignIntegration.php
@@ -81,7 +81,7 @@ abstract class BaseActiveCampaignIntegration extends CRMIntegration implements A
 
     public function checkConnection(Client $client): bool
     {
-        $response = $client->get($this->getEndpoint('/webhooks'));
+        $response = $client->get($this->getEndpoint('/users/me'));
 
         return 200 === $response->getStatusCode();
     }

--- a/packages/plugin/src/Integrations/EmailMarketing/ActiveCampaign/BaseActiveCampaignIntegration.php
+++ b/packages/plugin/src/Integrations/EmailMarketing/ActiveCampaign/BaseActiveCampaignIntegration.php
@@ -56,11 +56,9 @@ abstract class BaseActiveCampaignIntegration extends EmailMarketingIntegration i
 
     public function checkConnection(Client $client): bool
     {
-        $response = $client->get($this->getEndpoint('/lists?limit=100'));
+        $response = $client->get($this->getEndpoint('/users/me'));
 
-        $json = json_decode((string) $response->getBody(), true);
-
-        return !empty($json['lists']);
+        return 200 === $response->getStatusCode();
     }
 
     public function getApiToken(): string


### PR DESCRIPTION
We were previously check `/lists` endpoint but ActiveCampaign requires lists to be linked to a user group or account for the list to be available to use. 

From the docs...

>For a list to visible in the "accounts" ui, a user group needs to be assigned to the list.
If your newly-created Lists are not showing in the "accounts" user interface, it may be because a user group has not been to assigned to this List.

Lists also come back as empty array if the user hasn't got their accounts setup fully. We were checking for non-empty arrays too which is bad... Better to change to `/users/me` endpoint.