### PR TITLE
fix(SFT-2739): incorrect Yii2 hasOne key mapping in record classes

### DIFF
--- a/packages/plugin/src/Records/CrmFieldRecord.php
+++ b/packages/plugin/src/Records/CrmFieldRecord.php
@@ -39,6 +39,6 @@ class CrmFieldRecord extends ActiveRecord
      */
     public function getIntegration(): ActiveQuery
     {
-        return $this->hasOne(IntegrationRecord::class, ['integrationId' => 'id']);
+        return $this->hasOne(IntegrationRecord::class, ['id' => 'integrationId']);
     }
 }

--- a/packages/plugin/src/Records/EmailMarketingFieldRecord.php
+++ b/packages/plugin/src/Records/EmailMarketingFieldRecord.php
@@ -39,6 +39,6 @@ class EmailMarketingFieldRecord extends ActiveRecord
      */
     public function getMailingList(): ActiveQuery
     {
-        return $this->hasOne(EmailMarketingListRecord::class, ['mailingListId' => 'id']);
+        return $this->hasOne(EmailMarketingListRecord::class, ['id' => 'mailingListId']);
     }
 }

--- a/packages/plugin/src/Records/EmailMarketingListRecord.php
+++ b/packages/plugin/src/Records/EmailMarketingListRecord.php
@@ -42,6 +42,6 @@ class EmailMarketingListRecord extends ActiveRecord
      */
     public function getIntegration(): ActiveQuery
     {
-        return $this->hasOne(IntegrationRecord::class, ['integrationId' => 'id']);
+        return $this->hasOne(IntegrationRecord::class, ['id' => 'integrationId']);
     }
 }

--- a/packages/plugin/src/Records/Pro/Payments/PaymentRecord.php
+++ b/packages/plugin/src/Records/Pro/Payments/PaymentRecord.php
@@ -60,7 +60,7 @@ class PaymentRecord extends ActiveRecord
      */
     public function getIntegration(): ActiveQuery
     {
-        return $this->hasOne(IntegrationRecord::class, ['integrationId' => 'id']);
+        return $this->hasOne(IntegrationRecord::class, ['id' => 'integrationId']);
     }
 
     /**
@@ -68,7 +68,7 @@ class PaymentRecord extends ActiveRecord
      */
     public function getSubmission(): ActiveQuery
     {
-        return $this->hasOne(Submission::class, ['submissionId' => 'id']);
+        return $this->hasOne(Submission::class, ['id' => 'submissionId']);
     }
 
     public function getPaymentMethod(): ?\stdClass

--- a/packages/plugin/src/Records/UnfinalizedFileRecord.php
+++ b/packages/plugin/src/Records/UnfinalizedFileRecord.php
@@ -39,6 +39,6 @@ class UnfinalizedFileRecord extends ActiveRecord
      */
     public function getAsset(): ActiveQuery
     {
-        return $this->hasOne(Asset::class, ['assetId' => 'id']);
+        return $this->hasOne(Asset::class, ['id' => 'assetId']);
     }
 }


### PR DESCRIPTION
Fixes: #2495 

These are low-risk and no behaviour changes. Just bugs corrected in case these relations get used by third-party plugins querying these records.