### PR TITLE
fix(SFT-2746): export notifications sending multiple emails

### DIFF
--- a/packages/plugin/src/Bundles/Notifications/Export/ExportNotifications.php
+++ b/packages/plugin/src/Bundles/Notifications/Export/ExportNotifications.php
@@ -3,7 +3,6 @@
 namespace Solspace\Freeform\Bundles\Notifications\Export;
 
 use Carbon\Carbon;
-use craft\helpers\Db;
 use craft\helpers\StringHelper;
 use craft\web\Application;
 use Solspace\Freeform\Bundles\Notifications\Providers\NotificationLoggerProvider;
@@ -23,8 +22,9 @@ use yii\base\InvalidConfigException;
 
 class ExportNotifications extends FeatureBundle
 {
-    public const CACHE_KEY = 'export-notifications';
-    public const CACHE_TTL = 60 * 60 * 3; // every 3h
+    public const LOCK_KEY_EXPORT = 'export-notifications-lock-key';
+    public const CACHE_KEY_EXPORT = 'export-notifications';
+    public const CACHE_TTL_EXPORT = 60 * 60 * 3; // every 3h
 
     public const NOTIFICATION_TYPE = 'export-notification';
 
@@ -43,13 +43,17 @@ class ExportNotifications extends FeatureBundle
      */
     public function handleNotifications(): void
     {
-        if (Freeform::isLocked(self::CACHE_KEY, self::CACHE_TTL)) {
-            return;
-        }
-
         if (!\Craft::$app->db->tableExists(ExportNotificationRecord::TABLE)) {
             return;
         }
+
+        if (Freeform::isLockedWithGuard(self::CACHE_KEY_EXPORT, self::LOCK_KEY_EXPORT, self::CACHE_TTL_EXPORT)) {
+            return;
+        }
+
+        $logger = $this->notificationLoggerProvider->getLogger(null, null);
+
+        $logger->info('ExportNotifications handleNotifications - Started processing');
 
         $freeform = Freeform::getInstance();
         $mailer = $freeform->mailer;
@@ -61,8 +65,20 @@ class ExportNotifications extends FeatureBundle
             ->all()
         ;
 
+        $logger->debug('ExportNotifications handleNotifications - Found notifications', [
+            'count' => \count($notifications),
+        ]);
+
         foreach ($notifications as $notification) {
+            $logger->info("ExportNotifications handleNotifications - {$notification->name} - Started processing", [
+                'notification' => $notification,
+            ]);
+
             if (!$this->checkLock($notification)) {
+                $logger->info("ExportNotifications handleNotifications - {$notification->name} - Finished processing", [
+                    'notification' => $notification,
+                ]);
+
                 continue;
             }
 
@@ -93,7 +109,14 @@ class ExportNotifications extends FeatureBundle
             $recipients = RecipientCollection::fromArray(json_decode($notification->recipients));
             $processedRecipients = $mailer->processRecipients($recipients, $form);
 
-            $logger = $this->notificationLoggerProvider->getLogger($template, $form);
+            $logger->debug("ExportNotifications handleNotifications - {$notification->name} - Found recipients", [
+                'notification' => $notification,
+                'form' => $form,
+                'profile' => $profile,
+                'template' => $template,
+                'recipients' => $recipients->emailsToArray(),
+                'processedRecipients' => $processedRecipients,
+            ]);
 
             $message = $mailer->compileMessage($template, $variables, $logger);
             $message->setTo($processedRecipients);
@@ -121,57 +144,104 @@ class ExportNotifications extends FeatureBundle
                 ]
             );
 
-            $logger->info('Sending export notification', [
-                'form' => $form->getHandle(),
-                'profile' => $profile->name,
-                'recipients' => $processedRecipients,
+            $logger->info("ExportNotifications handleNotifications - {$notification->name} - Sending email", [
+                'recipients' => $recipients->emailsToArray(),
+                'processedRecipients' => $processedRecipients,
+                'message' => $message,
             ]);
 
             \Craft::$app->mailer->send($message);
+
+            $logger->info("ExportNotifications handleNotifications - {$notification->name} - Email sent");
+            $logger->info("ExportNotifications handleNotifications - {$notification->name} - Finished processing");
         }
+
+        $logger->info('ExportNotifications handleNotifications - Finished processing');
     }
 
     private function checkLock(ExportNotificationRecord $record): bool
     {
+        $logger = $this->notificationLoggerProvider->getLogger(null, null);
+
+        $logger->info("ExportNotifications checkLock - {$record->name} - Started processing");
+
         if (empty($record->getRecipientArray())) {
+            $logger->info("ExportNotifications checkLock - {$record->name} - Skipped - Recipients not found");
+            $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
             return false;
         }
 
         $frequency = (int) $record->frequency;
         $type = self::NOTIFICATION_TYPE;
 
-        $now = new Carbon('now');
+        // Use the Craft site timezone
+        $siteTimezone = new \DateTimeZone(\Craft::$app->getTimeZone());
 
-        $lookupStart = $now;
-        $lookupStart->setTime(0, 0, 0);
-        $lookupEnd = $lookupStart->copy()->setTime(23, 59, 59);
+        // "Today" at start of day in site timezone
+        $lookupStart = (new Carbon('now'))->setTimezone($siteTimezone)->startOfDay();
 
+        $logger->info("ExportNotifications checkLock - {$record->name} - lookupStart (Site Timezone) - {$lookupStart}");
+
+        // Frequency check:
+        // - Daily (-1) -> always run
+        // - Weekly (0–6) -> only run on that weekday in site timezone
         if (-1 !== $frequency && $lookupStart->dayOfWeek !== $frequency) {
+            $logger->info("ExportNotifications checkLock - {$record->name} - Skipped - Frequency mismatch (dayOfWeek={$lookupStart->dayOfWeek}, expected={$frequency})");
+            $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
             return false;
         }
 
-        $lock = NotificationLogRecord::find()
-            ->where(Db::parseDateParam('dateCreated', $lookupStart, '>='))
-            ->andWhere(Db::parseDateParam('dateCreated', $lookupEnd, '<='))
-            ->andWhere([
+        $exists = NotificationLogRecord::find()
+            ->where([
                 'type' => $type,
-                'identifier' => $record->id,
-                'name' => $record->name,
+                'identifier' => (string) $record->id,
+                'digestDate' => $lookupStart->toDateString(), // e.g. '2025-11-19'
             ])
-            ->one()
+            ->exists()
         ;
 
-        if ($lock) {
+        if ($exists) {
+            $logger->info("ExportNotifications checkLock - {$record->name} - Skipped - Already sent for {$lookupStart->toDateString()}");
+            $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
             return false;
         }
 
-        $lock = new NotificationLogRecord();
-        $lock->type = $type;
-        $lock->identifier = $record->id;
-        $lock->name = $record->name;
-        $lock->digestDate = $now->toDateString();
-        $lock->save();
+        $db = \Craft::$app->getDb();
+        $transaction = $db->beginTransaction();
 
-        return true;
+        try {
+            // Try to write log record to block duplicates
+            $notificationLogRecord = new NotificationLogRecord();
+            $notificationLogRecord->type = $type;
+            $notificationLogRecord->identifier = (string) $record->id;
+            $notificationLogRecord->name = $record->name;
+            $notificationLogRecord->digestDate = $lookupStart->toDateString();
+            $notificationLogRecord->save(false); // skip validation
+
+            $transaction->commit();
+
+            $logger->info("ExportNotifications checkLock - {$record->name} - Notification log record created");
+            $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
+            return true;
+        } catch (\Throwable $exception) {
+            $transaction->rollBack();
+
+            if (str_contains($exception->getMessage(), 'UNIQUE') || str_contains($exception->getMessage(), 'Duplicate')) {
+                $logger->warning("ExportNotifications checkLock - {$record->name} - Skipped - Already sent (duplicate record)");
+                $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
+                return false;
+            }
+
+            $logger->error("ExportNotifications checkLock - {$record->name} - Failed: {$exception->getMessage()}");
+            $logger->info("ExportNotifications checkLock - {$record->name} - Finished processing");
+
+            // Re-throw so the queue knows it failed
+            throw $exception;
+        }
     }
 }

--- a/packages/plugin/src/Bundles/Notifications/Providers/NotificationLoggerProvider.php
+++ b/packages/plugin/src/Bundles/Notifications/Providers/NotificationLoggerProvider.php
@@ -18,8 +18,9 @@ class NotificationLoggerProvider
 
     private int $level;
 
-    public function __construct(SettingsService $settingsService)
-    {
+    public function __construct(
+        SettingsService $settingsService
+    ) {
         $this->level = match ($settingsService->getSettingsModel()->loggingLevel) {
             Settings::LOGGING_LEVEL_INFO => Logger::INFO,
             Settings::LOGGING_LEVEL_DEBUG => Logger::DEBUG,
@@ -29,12 +30,13 @@ class NotificationLoggerProvider
 
     public function getLogger(
         NotificationInterface|NotificationTemplate|null $notification,
-        Form $form
+        ?Form $form
     ): LoggerInterface {
+        $logCategory = 'notification';
         if ($notification) {
-            $logCategory = StringHelper::toKebabCase($notification->getName());
-        } else {
-            $logCategory = 'form-'.$form->getId();
+            $logCategory = 'notification-'.StringHelper::toKebabCase($notification->getName());
+        } elseif ($form) {
+            $logCategory = 'notification-form-'.$form->getId();
         }
 
         return Freeform::getInstance()

--- a/packages/plugin/src/Services/Pro/DigestService.php
+++ b/packages/plugin/src/Services/Pro/DigestService.php
@@ -54,26 +54,28 @@ class DigestService extends Component
             return;
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Started processing');
+        $logger = $this->loggerProvider->getLogger();
+
+        $logger->info('DigestService triggerDigest - Started processing');
 
         $freeform = Freeform::getInstance();
         $settingsService = $freeform->settings;
 
         $isProduction = 'production' === strtolower(\Craft::$app->getConfig()->env);
         if (!$isProduction && $settingsService->isDigestOnlyOnProduction()) {
-            $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Skipped - Digest only allowed on Production');
-            $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished processing');
+            $logger->info('DigestService triggerDigest - Skipped - Digest only allowed on Production');
+            $logger->info('DigestService triggerDigest - Finished processing');
 
             return;
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest - Started processing');
+        $logger->info('DigestService triggerDigest - digest - Started processing');
 
         $devRecipients = $settingsService->getDigestRecipients();
         $devFrequency = $settingsService->getDigestFrequency();
 
         if ($devRecipients->count()) {
-            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - digest - Found recipients', [
+            $logger->debug('DigestService triggerDigest - digest - Found recipients', [
                 'recipients' => $devRecipients->emailsToArray(),
                 'frequency' => $devFrequency,
             ]);
@@ -86,14 +88,14 @@ class DigestService extends Component
             );
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest - Finished processing');
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest-client - Started processing');
+        $logger->info('DigestService triggerDigest - digest - Finished processing');
+        $logger->info('DigestService triggerDigest - digest-client - Started processing');
 
         $clientRecipients = $settingsService->getClientDigestRecipients();
         $clientFrequency = $settingsService->getClientDigestFrequency();
 
         if ($clientRecipients->count()) {
-            $this->loggerProvider->getLogger()->debug('DigestService triggerDigest - digest-client - Found recipients', [
+            $logger->debug('DigestService triggerDigest - digest-client - Found recipients', [
                 'recipients' => $clientRecipients->emailsToArray(),
                 'frequency' => $clientFrequency,
             ]);
@@ -106,13 +108,15 @@ class DigestService extends Component
             );
         }
 
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - digest-client - Finished processing');
-        $this->loggerProvider->getLogger()->info('DigestService triggerDigest - Finished processing');
+        $logger->info('DigestService triggerDigest - digest-client - Finished processing');
+        $logger->info('DigestService triggerDigest - Finished processing');
     }
 
     public function sendDigest(RecipientCollection $recipients, string $type, Carbon $rangeStart, Carbon $rangeEnd): void
     {
-        $this->loggerProvider->getLogger()->info("DigestService sendDigest - {$type} - Started processing");
+        $logger = $this->loggerProvider->getLogger();
+
+        $logger->info("DigestService sendDigest - {$type} - Started processing");
 
         $isFullDigest = NotificationLogRecord::TYPE_DIGEST_DEV === $type;
         $mailer = Freeform::getInstance()->mailer;
@@ -123,7 +127,7 @@ class DigestService extends Component
         $templatePath = \Craft::getAlias('@freeform/templates/'.self::TEMPLATE_PATH);
         $notification = NotificationTemplate::fromFile($templatePath);
 
-        $this->loggerProvider->getLogger()->info("DigestService sendDigest - {$type} - Sending email", [
+        $logger->info("DigestService sendDigest - {$type} - Sending email", [
             'recipients' => $recipients->emailsToArray(),
         ]);
 
@@ -146,8 +150,8 @@ class DigestService extends Component
         \Craft::$app->mailer->send($message);
         \Craft::$app->view->setTemplateMode($templateMode);
 
-        $this->loggerProvider->getLogger()->info("DigestService sendDigest - {$type} - Email sent");
-        $this->loggerProvider->getLogger()->info("DigestService sendDigest - {$type} - Finished processing");
+        $logger->info("DigestService sendDigest - {$type} - Email sent");
+        $logger->info("DigestService sendDigest - {$type} - Finished processing");
     }
 
     public function purgeNotificationLogs(): void
@@ -170,11 +174,13 @@ class DigestService extends Component
 
     private function parseDigest(string $type, RecipientCollection $recipients, int $frequency, Carbon $refDate): void
     {
-        $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Started processing");
+        $logger = $this->loggerProvider->getLogger();
+
+        $logger->info("DigestService parseDigest - {$type} - Started processing");
 
         if (empty($recipients->emailsToArray())) {
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Recipients not found");
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
+            $logger->info("DigestService parseDigest - {$type} - Skipped - Recipients not found");
+            $logger->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
@@ -186,14 +192,14 @@ class DigestService extends Component
         // "Today" at start of day in site timezone
         $lookupStart = $refDate->clone()->startOfDay();
 
-        $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - lookupStart (Site Timezone) - {$lookupStart}");
+        $logger->info("DigestService parseDigest - {$type} - lookupStart (Site Timezone) - {$lookupStart}");
 
         // Frequency check:
         // - Daily (-1) -> always run
         // - Weekly (0–6) -> only run on that weekday in site timezone
         if (-1 !== $frequency && $lookupStart->dayOfWeek !== $frequency) {
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Frequency mismatch (dayOfWeek={$lookupStart->dayOfWeek}, expected={$frequency})");
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
+            $logger->info("DigestService parseDigest - {$type} - Skipped - Frequency mismatch (dayOfWeek={$lookupStart->dayOfWeek}, expected={$frequency})");
+            $logger->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
@@ -202,14 +208,15 @@ class DigestService extends Component
         $exists = NotificationLogRecord::find()
             ->where([
                 'type' => $type,
+                'identifier' => $type,
                 'digestDate' => $lookupStart->toDateString(), // e.g. '2025-11-19'
             ])
             ->exists()
         ;
 
         if ($exists) {
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Skipped - Already sent for {$lookupStart->toDateString()}");
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
+            $logger->info("DigestService parseDigest - {$type} - Skipped - Already sent for {$lookupStart->toDateString()}");
+            $logger->info("DigestService parseDigest - {$type} - Finished processing");
 
             return;
         }
@@ -227,7 +234,7 @@ class DigestService extends Component
             $rangeEnd = $lookupStart->copy()->subDay()->endOfDay();
         }
 
-        $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Range (site timezone)", [
+        $logger->info("DigestService parseDigest - {$type} - Range (site timezone)", [
             'rangeStart' => $rangeStart,
             'rangeEnd' => $rangeEnd,
         ]);
@@ -237,34 +244,38 @@ class DigestService extends Component
 
         try {
             // Try to write log record to block duplicates
-            $record = new NotificationLogRecord();
-            $record->type = $type;
-            $record->digestDate = $lookupStart->toDateString(); // e.g. '2025-07-24'
-            $record->save(false); // skip validation
-
-            $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Notification log record created");
+            $notificationLogRecord = new NotificationLogRecord();
+            $notificationLogRecord->type = $type;
+            $notificationLogRecord->identifier = $type;
+            $notificationLogRecord->name = $type;
+            $notificationLogRecord->digestDate = $lookupStart->toDateString(); // e.g. '2025-07-24'
+            $notificationLogRecord->save(false); // skip validation
 
             $this->sendDigest($recipients, $type, $rangeStart, $rangeEnd);
 
             $transaction->commit();
+
+            $logger->info("DigestService parseDigest - {$type} - Notification log record created");
+            $logger->info("DigestService parseDigest - {$type} - Finished processing");
+
+            return;
         } catch (\Throwable $exception) {
             $transaction->rollBack();
 
             if (str_contains($exception->getMessage(), 'UNIQUE') || str_contains($exception->getMessage(), 'duplicate')) {
                 // Someone else already sent it
-                $this->loggerProvider->getLogger()->warning("DigestService parseDigest - {$type} - Skipped - Already sent (duplicate record)");
-                $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
+                $logger->warning("DigestService parseDigest - {$type} - Skipped - Already sent (duplicate record)");
+                $logger->info("DigestService parseDigest - {$type} - Finished processing");
 
                 return;
             }
 
-            $this->loggerProvider->getLogger()->error("DigestService parseDigest - {$type} - Failed: {$exception->getMessage()}");
+            $logger->error("DigestService parseDigest - {$type} - Failed: {$exception->getMessage()}");
+            $logger->info("DigestService parseDigest - {$type} - Finished processing");
 
             // Re-throw so the queue knows it failed
             throw $exception;
         }
-
-        $this->loggerProvider->getLogger()->info("DigestService parseDigest - {$type} - Finished processing");
     }
 
     private function getFormData(Carbon $rangeStart, Carbon $rangeEnd): array


### PR DESCRIPTION
Similar issue to what we have with daily digest emails. Needed our new isLockedWithGuard to prevent multiple PHP-FPM workers all passing the isLocked guard simultaneously, so the 2nd, 3rd, 4th worker still returned true and sent the email again. Also added debug logging so we can dig into things a bit more if issue continues to occur but I'm pretty certain its fixed now as I copied a lot of the fixes from DigestService. 