### PR TITLE
fix(SFT-2755): allow single letter domain names in website field type validation

### DIFF
--- a/packages/plugin/src/Bundles/Fields/Validation/WebsiteValidation.php
+++ b/packages/plugin/src/Bundles/Fields/Validation/WebsiteValidation.php
@@ -11,7 +11,7 @@ use yii\base\Event;
 
 class WebsiteValidation extends FeatureBundle
 {
-    private const PATTERN = '/^((((http(s)?)|(sftp)|(ftp)|(ssh)):\/\/)|(\/\/))?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,15}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)$/i';
+    private const PATTERN = '/^((((http(s)?)|(sftp)|(ftp)|(ssh)):\/\/)|(\/\/))?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,15}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)$/i';
 
     public function __construct()
     {


### PR DESCRIPTION
Fixes https://github.com/solspace/craft-freeform/issues/2504