### PR TITLE
fix(SFT-2756): submissions restore button when viewing trashed list

### DIFF
--- a/packages/plugin/src/Elements/Submission.php
+++ b/packages/plugin/src/Elements/Submission.php
@@ -472,6 +472,11 @@ class Submission extends Element
         return self::$permissionCache[$this->formId];
     }
 
+    public function canSave(User $user): bool
+    {
+        return $this->getIsEditable();
+    }
+
     public function canView(User $user): bool
     {
         return true;


### PR DESCRIPTION
Fixes: https://github.com/solspace/craft-freeform/issues/2498

Missing data-savable attribute on table rows which is used to enable/disable restore button on element index pages.